### PR TITLE
[FIX] Changes so validator object is not leaked to composed component

### DIFF
--- a/src/withValidation.js
+++ b/src/withValidation.js
@@ -144,7 +144,7 @@ function withValidation(ComposedComponent) {
 		};
 
 		render() {
-			const { name, validateOn, validate, ...rest } = this.props;
+			const { name, validateOn, validate, validator, ...rest } = this.props;
 			const validationResult =
 				this.validator && this.validator.validationResult && this.validator.validationResult[name];
 			const isInvalid = validationResult && validationResult.isInvalid;


### PR DESCRIPTION
Changes so `validator` object is not passed on to composed component when using `withValidation` HOC.