### PR TITLE
Expose validator to composed component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
 			"integrity": "sha512-zbO/DtTnaDappBflIU3zYEgATLToRDmW5uN/EGH1GXaes7ydfjqmAoK++xmJIA+8HfDw7UyPZNdM8fhGhfmMhw==",
 			"dev": true,
 			"requires": {
-				"chokidar": "2.0.4",
-				"commander": "2.19.0",
-				"convert-source-map": "1.6.0",
-				"fs-readdir-recursive": "1.1.0",
-				"glob": "7.1.3",
-				"lodash": "4.17.11",
-				"mkdirp": "0.5.1",
-				"output-file-sync": "2.0.1",
-				"slash": "2.0.0",
-				"source-map": "0.5.7"
+				"chokidar": "^2.0.3",
+				"commander": "^2.8.1",
+				"convert-source-map": "^1.1.0",
+				"fs-readdir-recursive": "^1.1.0",
+				"glob": "^7.0.0",
+				"lodash": "^4.17.10",
+				"mkdirp": "^0.5.1",
+				"output-file-sync": "^2.0.0",
+				"slash": "^2.0.0",
+				"source-map": "^0.5.0"
 			},
 			"dependencies": {
 				"slash": {
@@ -36,7 +36,7 @@
 			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0"
+				"@babel/highlight": "^7.0.0"
 			}
 		},
 		"@babel/core": {
@@ -45,20 +45,20 @@
 			"integrity": "sha512-vOyH020C56tQvte++i+rX2yokZcRfbv/kKcw+/BCRw/cK6dvsr47aCzm8oC1XHwMSEWbqrZKzZRLzLnq6SFMsg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0",
-				"@babel/generator": "7.1.5",
-				"@babel/helpers": "7.1.5",
-				"@babel/parser": "7.1.5",
-				"@babel/template": "7.1.2",
-				"@babel/traverse": "7.1.5",
-				"@babel/types": "7.1.5",
-				"convert-source-map": "1.6.0",
-				"debug": "3.2.6",
-				"json5": "0.5.1",
-				"lodash": "4.17.11",
-				"resolve": "1.8.1",
-				"semver": "5.6.0",
-				"source-map": "0.5.7"
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.1.5",
+				"@babel/helpers": "^7.1.5",
+				"@babel/parser": "^7.1.5",
+				"@babel/template": "^7.1.2",
+				"@babel/traverse": "^7.1.5",
+				"@babel/types": "^7.1.5",
+				"convert-source-map": "^1.1.0",
+				"debug": "^3.1.0",
+				"json5": "^0.5.0",
+				"lodash": "^4.17.10",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/generator": {
@@ -67,11 +67,11 @@
 			"integrity": "sha512-IO31r62xfMI+wBJVmgx0JR9ZOHty8HkoYpQAjRWUGG9vykBTlGHdArZ8zoFtpUu2gs17K7qTl/TtPpiSi6t+MA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.1.5",
-				"jsesc": "2.5.2",
-				"lodash": "4.17.11",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"@babel/types": "^7.1.5",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.10",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
@@ -80,7 +80,7 @@
 			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.1.5"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -89,8 +89,8 @@
 			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "7.1.0",
-				"@babel/types": "7.1.5"
+				"@babel/helper-explode-assignable-expression": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
@@ -99,8 +99,8 @@
 			"integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.1.5",
-				"esutils": "2.0.2"
+				"@babel/types": "^7.0.0",
+				"esutils": "^2.0.0"
 			}
 		},
 		"@babel/helper-call-delegate": {
@@ -109,9 +109,9 @@
 			"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0",
-				"@babel/traverse": "7.1.5",
-				"@babel/types": "7.1.5"
+				"@babel/helper-hoist-variables": "^7.0.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-define-map": {
@@ -120,9 +120,9 @@
 			"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.1.0",
-				"@babel/types": "7.1.5",
-				"lodash": "4.17.11"
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
@@ -131,8 +131,8 @@
 			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "7.1.5",
-				"@babel/types": "7.1.5"
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-function-name": {
@@ -141,9 +141,9 @@
 			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0",
-				"@babel/template": "7.1.2",
-				"@babel/types": "7.1.5"
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-get-function-arity": {
@@ -152,7 +152,7 @@
 			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.1.5"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
@@ -161,7 +161,7 @@
 			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.1.5"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -170,7 +170,7 @@
 			"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.1.5"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -179,7 +179,7 @@
 			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.1.5"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-module-transforms": {
@@ -188,12 +188,12 @@
 			"integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0",
-				"@babel/helper-simple-access": "7.1.0",
-				"@babel/helper-split-export-declaration": "7.0.0",
-				"@babel/template": "7.1.2",
-				"@babel/types": "7.1.5",
-				"lodash": "4.17.11"
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -202,7 +202,7 @@
 			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.1.5"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -217,7 +217,7 @@
 			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.11"
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
@@ -226,11 +226,11 @@
 			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0",
-				"@babel/helper-wrap-function": "7.1.0",
-				"@babel/template": "7.1.2",
-				"@babel/traverse": "7.1.5",
-				"@babel/types": "7.1.5"
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-wrap-function": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-replace-supers": {
@@ -239,10 +239,10 @@
 			"integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "7.0.0",
-				"@babel/helper-optimise-call-expression": "7.0.0",
-				"@babel/traverse": "7.1.5",
-				"@babel/types": "7.1.5"
+				"@babel/helper-member-expression-to-functions": "^7.0.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -251,8 +251,8 @@
 			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.1.2",
-				"@babel/types": "7.1.5"
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
@@ -261,7 +261,7 @@
 			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.1.5"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-wrap-function": {
@@ -270,10 +270,10 @@
 			"integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.1.0",
-				"@babel/template": "7.1.2",
-				"@babel/traverse": "7.1.5",
-				"@babel/types": "7.1.5"
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helpers": {
@@ -282,9 +282,9 @@
 			"integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "7.1.2",
-				"@babel/traverse": "7.1.5",
-				"@babel/types": "7.1.5"
+				"@babel/template": "^7.1.2",
+				"@babel/traverse": "^7.1.5",
+				"@babel/types": "^7.1.5"
 			}
 		},
 		"@babel/highlight": {
@@ -293,9 +293,9 @@
 			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"esutils": "2.0.2",
-				"js-tokens": "4.0.0"
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
@@ -310,9 +310,9 @@
 			"integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/helper-remap-async-to-generator": "7.1.0",
-				"@babel/plugin-syntax-async-generators": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0",
+				"@babel/plugin-syntax-async-generators": "^7.0.0"
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
@@ -321,12 +321,12 @@
 			"integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.1.0",
-				"@babel/helper-member-expression-to-functions": "7.0.0",
-				"@babel/helper-optimise-call-expression": "7.0.0",
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/helper-replace-supers": "7.1.0",
-				"@babel/plugin-syntax-class-properties": "7.0.0"
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-member-expression-to-functions": "^7.0.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0",
+				"@babel/plugin-syntax-class-properties": "^7.0.0"
 			}
 		},
 		"@babel/plugin-proposal-decorators": {
@@ -335,10 +335,10 @@
 			"integrity": "sha512-YooynBO6PmBgHvAd0fl5e5Tq/a0pEC6RqF62ouafme8FzdIVH41Mz/u1dn8fFVm4jzEJ+g/MsOxouwybJPuP8Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/helper-replace-supers": "7.1.0",
-				"@babel/helper-split-export-declaration": "7.0.0",
-				"@babel/plugin-syntax-decorators": "7.1.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/plugin-syntax-decorators": "^7.1.0"
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
@@ -347,8 +347,8 @@
 			"integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/plugin-syntax-json-strings": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-json-strings": "^7.0.0"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
@@ -357,8 +357,8 @@
 			"integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
@@ -367,8 +367,8 @@
 			"integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
@@ -377,9 +377,9 @@
 			"integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/helper-regex": "7.0.0",
-				"regexpu-core": "4.2.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
+				"regexpu-core": "^4.2.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -388,7 +388,7 @@
 			"integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-class-properties": {
@@ -397,7 +397,7 @@
 			"integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-decorators": {
@@ -406,7 +406,7 @@
 			"integrity": "sha512-uQvRSbgQ0nQg3jsmIixXXDCgSpkBolJ9X7NYThMKCcjvE8dN2uWJUzTUNNAeuKOjARTd+wUQV0ztXpgunZYKzQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-json-strings": {
@@ -415,7 +415,7 @@
 			"integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
@@ -424,7 +424,7 @@
 			"integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
@@ -433,7 +433,7 @@
 			"integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-optional-catch-binding": {
@@ -442,7 +442,7 @@
 			"integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
@@ -451,7 +451,7 @@
 			"integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
@@ -460,9 +460,9 @@
 			"integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0",
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/helper-remap-async-to-generator": "7.1.0"
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
@@ -471,7 +471,7 @@
 			"integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
@@ -480,8 +480,8 @@
 			"integrity": "sha512-jlYcDrz+5ayWC7mxgpn1Wj8zj0mmjCT2w0mPIMSwO926eXBRxpEgoN/uQVRBfjtr8ayjcmS+xk2G1jaP8JjMJQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"lodash": "4.17.11"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/plugin-transform-classes": {
@@ -490,14 +490,14 @@
 			"integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0",
-				"@babel/helper-define-map": "7.1.0",
-				"@babel/helper-function-name": "7.1.0",
-				"@babel/helper-optimise-call-expression": "7.0.0",
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/helper-replace-supers": "7.1.0",
-				"@babel/helper-split-export-declaration": "7.0.0",
-				"globals": "11.8.0"
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-define-map": "^7.1.0",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
@@ -506,7 +506,7 @@
 			"integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
@@ -515,7 +515,7 @@
 			"integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
@@ -524,9 +524,9 @@
 			"integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/helper-regex": "7.0.0",
-				"regexpu-core": "4.2.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
+				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
@@ -535,7 +535,7 @@
 			"integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
@@ -544,8 +544,8 @@
 			"integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
@@ -554,7 +554,7 @@
 			"integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
@@ -563,8 +563,8 @@
 			"integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "7.1.0",
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-literals": {
@@ -573,7 +573,7 @@
 			"integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
@@ -582,8 +582,8 @@
 			"integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.1.0",
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
@@ -592,9 +592,9 @@
 			"integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.1.0",
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/helper-simple-access": "7.1.0"
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
@@ -603,8 +603,8 @@
 			"integrity": "sha512-PvTxgjxQAq4pvVUZF3mD5gEtVDuId8NtWkJsZLEJZMZAW3TvgQl1pmydLLN1bM8huHFVVU43lf0uvjQj9FRkKw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0",
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-hoist-variables": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
@@ -613,8 +613,8 @@
 			"integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "7.1.0",
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -623,7 +623,7 @@
 			"integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
@@ -632,8 +632,8 @@
 			"integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/helper-replace-supers": "7.1.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
@@ -642,9 +642,9 @@
 			"integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-call-delegate": "7.1.0",
-				"@babel/helper-get-function-arity": "7.0.0",
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-call-delegate": "^7.1.0",
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-display-name": {
@@ -653,7 +653,7 @@
 			"integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
@@ -662,9 +662,9 @@
 			"integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx": "7.0.0",
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/plugin-syntax-jsx": "7.0.0"
+				"@babel/helper-builder-react-jsx": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-jsx-self": {
@@ -673,8 +673,8 @@
 			"integrity": "sha512-pymy+AK12WO4safW1HmBpwagUQRl9cevNX+82AIAtU1pIdugqcH+nuYP03Ja6B+N4gliAaKWAegIBL/ymALPHA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/plugin-syntax-jsx": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-jsx-source": {
@@ -683,8 +683,8 @@
 			"integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/plugin-syntax-jsx": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
@@ -693,7 +693,7 @@
 			"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
 			"dev": true,
 			"requires": {
-				"regenerator-transform": "0.13.3"
+				"regenerator-transform": "^0.13.3"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
@@ -702,7 +702,7 @@
 			"integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-spread": {
@@ -711,7 +711,7 @@
 			"integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
@@ -720,8 +720,8 @@
 			"integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/helper-regex": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
@@ -730,8 +730,8 @@
 			"integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0",
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
@@ -740,7 +740,7 @@
 			"integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
@@ -749,9 +749,9 @@
 			"integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/helper-regex": "7.0.0",
-				"regexpu-core": "4.2.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
+				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/preset-env": {
@@ -760,47 +760,47 @@
 			"integrity": "sha512-pQ+2o0YyCp98XG0ODOHJd9z4GsSoV5jicSedRwCrU8uiqcJahwQiOq0asSZEb/m/lwyu6X5INvH/DSiwnQKncw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0",
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/plugin-proposal-async-generator-functions": "7.1.0",
-				"@babel/plugin-proposal-json-strings": "7.0.0",
-				"@babel/plugin-proposal-object-rest-spread": "7.0.0",
-				"@babel/plugin-proposal-optional-catch-binding": "7.0.0",
-				"@babel/plugin-proposal-unicode-property-regex": "7.0.0",
-				"@babel/plugin-syntax-async-generators": "7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0",
-				"@babel/plugin-syntax-optional-catch-binding": "7.0.0",
-				"@babel/plugin-transform-arrow-functions": "7.0.0",
-				"@babel/plugin-transform-async-to-generator": "7.1.0",
-				"@babel/plugin-transform-block-scoped-functions": "7.0.0",
-				"@babel/plugin-transform-block-scoping": "7.1.5",
-				"@babel/plugin-transform-classes": "7.1.0",
-				"@babel/plugin-transform-computed-properties": "7.0.0",
-				"@babel/plugin-transform-destructuring": "7.1.3",
-				"@babel/plugin-transform-dotall-regex": "7.0.0",
-				"@babel/plugin-transform-duplicate-keys": "7.0.0",
-				"@babel/plugin-transform-exponentiation-operator": "7.1.0",
-				"@babel/plugin-transform-for-of": "7.0.0",
-				"@babel/plugin-transform-function-name": "7.1.0",
-				"@babel/plugin-transform-literals": "7.0.0",
-				"@babel/plugin-transform-modules-amd": "7.1.0",
-				"@babel/plugin-transform-modules-commonjs": "7.1.0",
-				"@babel/plugin-transform-modules-systemjs": "7.1.3",
-				"@babel/plugin-transform-modules-umd": "7.1.0",
-				"@babel/plugin-transform-new-target": "7.0.0",
-				"@babel/plugin-transform-object-super": "7.1.0",
-				"@babel/plugin-transform-parameters": "7.1.0",
-				"@babel/plugin-transform-regenerator": "7.0.0",
-				"@babel/plugin-transform-shorthand-properties": "7.0.0",
-				"@babel/plugin-transform-spread": "7.0.0",
-				"@babel/plugin-transform-sticky-regex": "7.0.0",
-				"@babel/plugin-transform-template-literals": "7.0.0",
-				"@babel/plugin-transform-typeof-symbol": "7.0.0",
-				"@babel/plugin-transform-unicode-regex": "7.0.0",
-				"browserslist": "4.3.4",
-				"invariant": "2.2.4",
-				"js-levenshtein": "1.1.4",
-				"semver": "5.6.0"
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-proposal-async-generator-functions": "^7.1.0",
+				"@babel/plugin-proposal-json-strings": "^7.0.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+				"@babel/plugin-syntax-async-generators": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+				"@babel/plugin-transform-arrow-functions": "^7.0.0",
+				"@babel/plugin-transform-async-to-generator": "^7.1.0",
+				"@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+				"@babel/plugin-transform-block-scoping": "^7.1.5",
+				"@babel/plugin-transform-classes": "^7.1.0",
+				"@babel/plugin-transform-computed-properties": "^7.0.0",
+				"@babel/plugin-transform-destructuring": "^7.0.0",
+				"@babel/plugin-transform-dotall-regex": "^7.0.0",
+				"@babel/plugin-transform-duplicate-keys": "^7.0.0",
+				"@babel/plugin-transform-exponentiation-operator": "^7.1.0",
+				"@babel/plugin-transform-for-of": "^7.0.0",
+				"@babel/plugin-transform-function-name": "^7.1.0",
+				"@babel/plugin-transform-literals": "^7.0.0",
+				"@babel/plugin-transform-modules-amd": "^7.1.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.1.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.0.0",
+				"@babel/plugin-transform-modules-umd": "^7.1.0",
+				"@babel/plugin-transform-new-target": "^7.0.0",
+				"@babel/plugin-transform-object-super": "^7.1.0",
+				"@babel/plugin-transform-parameters": "^7.1.0",
+				"@babel/plugin-transform-regenerator": "^7.0.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+				"@babel/plugin-transform-spread": "^7.0.0",
+				"@babel/plugin-transform-sticky-regex": "^7.0.0",
+				"@babel/plugin-transform-template-literals": "^7.0.0",
+				"@babel/plugin-transform-typeof-symbol": "^7.0.0",
+				"@babel/plugin-transform-unicode-regex": "^7.0.0",
+				"browserslist": "^4.1.0",
+				"invariant": "^2.2.2",
+				"js-levenshtein": "^1.1.3",
+				"semver": "^5.3.0"
 			}
 		},
 		"@babel/preset-react": {
@@ -809,11 +809,11 @@
 			"integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0",
-				"@babel/plugin-transform-react-display-name": "7.0.0",
-				"@babel/plugin-transform-react-jsx": "7.0.0",
-				"@babel/plugin-transform-react-jsx-self": "7.0.0",
-				"@babel/plugin-transform-react-jsx-source": "7.0.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-transform-react-display-name": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/plugin-transform-react-jsx-self": "^7.0.0",
+				"@babel/plugin-transform-react-jsx-source": "^7.0.0"
 			}
 		},
 		"@babel/runtime": {
@@ -822,7 +822,7 @@
 			"integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
 			"dev": true,
 			"requires": {
-				"regenerator-runtime": "0.12.1"
+				"regenerator-runtime": "^0.12.0"
 			},
 			"dependencies": {
 				"regenerator-runtime": {
@@ -839,9 +839,9 @@
 			"integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0",
-				"@babel/parser": "7.1.5",
-				"@babel/types": "7.1.5"
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.1.2",
+				"@babel/types": "^7.1.2"
 			}
 		},
 		"@babel/traverse": {
@@ -850,15 +850,15 @@
 			"integrity": "sha512-eU6XokWypl0MVJo+MTSPUtlfPePkrqsF26O+l1qFGlCKWwmiYAYy2Sy44Qw8m2u/LbPCsxYt90rghmqhYMGpPA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0",
-				"@babel/generator": "7.1.5",
-				"@babel/helper-function-name": "7.1.0",
-				"@babel/helper-split-export-declaration": "7.0.0",
-				"@babel/parser": "7.1.5",
-				"@babel/types": "7.1.5",
-				"debug": "3.2.6",
-				"globals": "11.8.0",
-				"lodash": "4.17.11"
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.1.5",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/parser": "^7.1.5",
+				"@babel/types": "^7.1.5",
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/types": {
@@ -867,9 +867,9 @@
 			"integrity": "sha512-sJeqa/d9eM/bax8Ivg+fXF7FpN3E/ZmTrWbkk6r+g7biVYfALMnLin4dKijsaqEhpd2xvOGfQTkQkD31YCVV4A==",
 			"dev": true,
 			"requires": {
-				"esutils": "2.0.2",
-				"lodash": "4.17.11",
-				"to-fast-properties": "2.0.0"
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.10",
+				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@types/node": {
@@ -952,7 +952,7 @@
 			"integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
 			"dev": true,
 			"requires": {
-				"@xtuc/ieee754": "1.2.0"
+				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
@@ -1080,7 +1080,7 @@
 			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.7.3"
+				"acorn": "^5.0.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -1097,8 +1097,8 @@
 			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
 			"dev": true,
 			"requires": {
-				"acorn": "6.0.4",
-				"acorn-walk": "6.1.0"
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
 			}
 		},
 		"acorn-walk": {
@@ -1113,10 +1113,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ajv-keywords": {
@@ -1143,7 +1143,7 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "1.9.3"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"anymatch": {
@@ -1152,8 +1152,8 @@
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
-				"micromatch": "3.1.10",
-				"normalize-path": "2.1.1"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -1174,16 +1174,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.3",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1192,7 +1192,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1212,13 +1212,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1227,7 +1227,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -1236,7 +1236,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -1245,7 +1245,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -1254,7 +1254,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1265,7 +1265,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -1274,7 +1274,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1285,9 +1285,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -1304,14 +1304,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1320,7 +1320,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -1329,7 +1329,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1340,10 +1340,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1352,7 +1352,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1363,7 +1363,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -1372,7 +1372,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -1381,9 +1381,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"is-number": {
@@ -1392,7 +1392,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1401,7 +1401,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1418,19 +1418,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.13",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"ms": {
@@ -1447,7 +1447,7 @@
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "1.0.0"
+				"default-require-extensions": "^1.0.0"
 			}
 		},
 		"aproba": {
@@ -1462,7 +1462,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arr-diff": {
@@ -1471,7 +1471,7 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "1.1.0"
+				"arr-flatten": "^1.0.1"
 			}
 		},
 		"arr-flatten": {
@@ -1504,9 +1504,9 @@
 			"integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"es-abstract": "1.12.0",
-				"function-bind": "1.1.1"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.10.0",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"arrify": {
@@ -1521,7 +1521,7 @@
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": "~2.1.0"
 			}
 		},
 		"asn1.js": {
@@ -1530,9 +1530,9 @@
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.1"
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"assert": {
@@ -1585,7 +1585,7 @@
 			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.11"
+				"lodash": "^4.17.10"
 			}
 		},
 		"async-each": {
@@ -1630,9 +1630,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -1647,11 +1647,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"js-tokens": {
@@ -1680,14 +1680,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.11",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -1704,8 +1704,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-jest": {
@@ -1714,8 +1714,8 @@
 			"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "4.1.6",
-				"babel-preset-jest": "23.2.0"
+				"babel-plugin-istanbul": "^4.1.6",
+				"babel-preset-jest": "^23.2.0"
 			}
 		},
 		"babel-loader": {
@@ -1724,10 +1724,10 @@
 			"integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "1.0.0",
-				"loader-utils": "1.1.0",
-				"mkdirp": "0.5.1",
-				"util.promisify": "1.0.0"
+				"find-cache-dir": "^1.0.0",
+				"loader-utils": "^1.0.2",
+				"mkdirp": "^0.5.1",
+				"util.promisify": "^1.0.0"
 			}
 		},
 		"babel-messages": {
@@ -1736,7 +1736,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -1745,10 +1745,10 @@
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"find-up": "2.1.0",
-				"istanbul-lib-instrument": "1.10.2",
-				"test-exclude": "4.2.3"
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
+				"find-up": "^2.1.0",
+				"istanbul-lib-instrument": "^1.10.1",
+				"test-exclude": "^4.2.1"
 			}
 		},
 		"babel-plugin-jest-hoist": {
@@ -1769,8 +1769,8 @@
 			"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "23.2.0",
-				"babel-plugin-syntax-object-rest-spread": "6.13.0"
+				"babel-plugin-jest-hoist": "^23.2.0",
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
 			}
 		},
 		"babel-register": {
@@ -1779,13 +1779,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.26.3",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.7",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.11",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
+				"babel-core": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.17.4",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.15"
 			},
 			"dependencies": {
 				"babel-core": {
@@ -1794,25 +1794,25 @@
 					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-generator": "6.26.1",
-						"babel-helpers": "6.24.1",
-						"babel-messages": "6.23.0",
-						"babel-register": "6.26.0",
-						"babel-runtime": "6.26.0",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"convert-source-map": "1.6.0",
-						"debug": "2.6.9",
-						"json5": "0.5.1",
-						"lodash": "4.17.11",
-						"minimatch": "3.0.4",
-						"path-is-absolute": "1.0.1",
-						"private": "0.1.8",
-						"slash": "1.0.0",
-						"source-map": "0.5.7"
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
 					}
 				},
 				"debug": {
@@ -1838,8 +1838,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.7",
-				"regenerator-runtime": "0.11.1"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
 			}
 		},
 		"babel-template": {
@@ -1848,11 +1848,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.11"
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -1861,15 +1861,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.4",
-				"lodash": "4.17.11"
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
 			},
 			"dependencies": {
 				"debug": {
@@ -1901,10 +1901,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.11",
-				"to-fast-properties": "1.0.3"
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			},
 			"dependencies": {
 				"to-fast-properties": {
@@ -1933,13 +1933,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "1.0.1",
-				"class-utils": "0.3.6",
-				"component-emitter": "1.2.1",
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"mixin-deep": "1.3.1",
-				"pascalcase": "0.1.1"
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1948,7 +1948,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -1957,7 +1957,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -1966,7 +1966,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -1975,9 +1975,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"kind-of": {
@@ -2000,7 +2000,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"dev": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"big.js": {
@@ -2039,7 +2039,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -2049,9 +2049,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.3"
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"brorand": {
@@ -2089,12 +2089,12 @@
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"dev": true,
 			"requires": {
-				"buffer-xor": "1.0.3",
-				"cipher-base": "1.0.4",
-				"create-hash": "1.2.0",
-				"evp_bytestokey": "1.0.3",
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.2"
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"browserify-cipher": {
@@ -2103,9 +2103,9 @@
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
 			"dev": true,
 			"requires": {
-				"browserify-aes": "1.2.0",
-				"browserify-des": "1.0.2",
-				"evp_bytestokey": "1.0.3"
+				"browserify-aes": "^1.0.4",
+				"browserify-des": "^1.0.0",
+				"evp_bytestokey": "^1.0.0"
 			}
 		},
 		"browserify-des": {
@@ -2114,10 +2114,10 @@
 			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"des.js": "1.0.0",
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.2"
+				"cipher-base": "^1.0.1",
+				"des.js": "^1.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"browserify-rsa": {
@@ -2126,8 +2126,8 @@
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"randombytes": "2.0.6"
+				"bn.js": "^4.1.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"browserify-sign": {
@@ -2136,13 +2136,13 @@
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.2.0",
-				"create-hmac": "1.1.7",
-				"elliptic": "6.4.1",
-				"inherits": "2.0.3",
-				"parse-asn1": "5.1.1"
+				"bn.js": "^4.1.1",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.2",
+				"elliptic": "^6.0.0",
+				"inherits": "^2.0.1",
+				"parse-asn1": "^5.0.0"
 			}
 		},
 		"browserify-zlib": {
@@ -2151,7 +2151,7 @@
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"dev": true,
 			"requires": {
-				"pako": "1.0.6"
+				"pako": "~1.0.5"
 			}
 		},
 		"browserslist": {
@@ -2160,9 +2160,9 @@
 			"integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "1.0.30000907",
-				"electron-to-chromium": "1.3.84",
-				"node-releases": "1.0.3"
+				"caniuse-lite": "^1.0.30000899",
+				"electron-to-chromium": "^1.3.82",
+				"node-releases": "^1.0.1"
 			}
 		},
 		"bser": {
@@ -2171,7 +2171,7 @@
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"dev": true,
 			"requires": {
-				"node-int64": "0.4.0"
+				"node-int64": "^0.4.0"
 			}
 		},
 		"buffer": {
@@ -2180,9 +2180,9 @@
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"dev": true,
 			"requires": {
-				"base64-js": "1.3.0",
-				"ieee754": "1.1.12",
-				"isarray": "1.0.0"
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4",
+				"isarray": "^1.0.0"
 			}
 		},
 		"buffer-from": {
@@ -2215,19 +2215,19 @@
 			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 			"dev": true,
 			"requires": {
-				"bluebird": "3.5.3",
-				"chownr": "1.1.1",
-				"glob": "7.1.3",
-				"graceful-fs": "4.1.15",
-				"lru-cache": "4.1.3",
-				"mississippi": "2.0.0",
-				"mkdirp": "0.5.1",
-				"move-concurrently": "1.0.1",
-				"promise-inflight": "1.0.1",
-				"rimraf": "2.6.2",
-				"ssri": "5.3.0",
-				"unique-filename": "1.1.1",
-				"y18n": "4.0.0"
+				"bluebird": "^3.5.1",
+				"chownr": "^1.0.1",
+				"glob": "^7.1.2",
+				"graceful-fs": "^4.1.11",
+				"lru-cache": "^4.1.1",
+				"mississippi": "^2.0.0",
+				"mkdirp": "^0.5.1",
+				"move-concurrently": "^1.0.1",
+				"promise-inflight": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"ssri": "^5.2.4",
+				"unique-filename": "^1.1.0",
+				"y18n": "^4.0.0"
 			},
 			"dependencies": {
 				"y18n": {
@@ -2244,15 +2244,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "1.0.0",
-				"component-emitter": "1.2.1",
-				"get-value": "2.0.6",
-				"has-value": "1.0.0",
-				"isobject": "3.0.1",
-				"set-value": "2.0.0",
-				"to-object-path": "0.3.0",
-				"union-value": "1.0.0",
-				"unset-value": "1.0.0"
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
 			}
 		},
 		"callsites": {
@@ -2273,7 +2273,7 @@
 			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
 			"dev": true,
 			"requires": {
-				"rsvp": "3.6.2"
+				"rsvp": "^3.3.3"
 			}
 		},
 		"caseless": {
@@ -2288,9 +2288,9 @@
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.5.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"cheerio": {
@@ -2299,12 +2299,12 @@
 			"integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
 			"dev": true,
 			"requires": {
-				"css-select": "1.2.0",
-				"dom-serializer": "0.1.0",
-				"entities": "1.1.2",
-				"htmlparser2": "3.10.0",
-				"lodash": "4.17.11",
-				"parse5": "3.0.3"
+				"css-select": "~1.2.0",
+				"dom-serializer": "~0.1.0",
+				"entities": "~1.1.1",
+				"htmlparser2": "^3.9.1",
+				"lodash": "^4.15.0",
+				"parse5": "^3.0.1"
 			}
 		},
 		"chokidar": {
@@ -2313,19 +2313,19 @@
 			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
 			"dev": true,
 			"requires": {
-				"anymatch": "2.0.0",
-				"async-each": "1.0.1",
-				"braces": "2.3.2",
-				"fsevents": "1.2.4",
-				"glob-parent": "3.1.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "4.0.0",
-				"lodash.debounce": "4.0.8",
-				"normalize-path": "2.1.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.2.1",
-				"upath": "1.1.0"
+				"anymatch": "^2.0.0",
+				"async-each": "^1.0.0",
+				"braces": "^2.3.0",
+				"fsevents": "^1.2.2",
+				"glob-parent": "^3.1.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"lodash.debounce": "^4.0.8",
+				"normalize-path": "^2.1.1",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0",
+				"upath": "^1.0.5"
 			},
 			"dependencies": {
 				"array-unique": {
@@ -2340,16 +2340,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.3",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					}
 				},
 				"extend-shallow": {
@@ -2358,7 +2358,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"fill-range": {
@@ -2367,10 +2367,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					}
 				},
 				"glob-parent": {
@@ -2379,8 +2379,8 @@
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"dev": true,
 					"requires": {
-						"is-glob": "3.1.0",
-						"path-dirname": "1.0.2"
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
 					},
 					"dependencies": {
 						"is-glob": {
@@ -2389,7 +2389,7 @@
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"dev": true,
 							"requires": {
-								"is-extglob": "2.1.1"
+								"is-extglob": "^2.1.0"
 							}
 						}
 					}
@@ -2406,7 +2406,7 @@
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				},
 				"is-number": {
@@ -2415,7 +2415,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				}
 			}
@@ -2432,7 +2432,7 @@
 			"integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
 			"dev": true,
 			"requires": {
-				"tslib": "1.9.3"
+				"tslib": "^1.9.0"
 			}
 		},
 		"ci-info": {
@@ -2447,8 +2447,8 @@
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.2"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"class-utils": {
@@ -2457,10 +2457,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"define-property": "0.2.5",
-				"isobject": "3.0.1",
-				"static-extend": "0.1.2"
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2469,7 +2469,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -2480,9 +2480,9 @@
 			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 			"dev": true,
 			"requires": {
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"wrap-ansi": "2.1.0"
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -2497,7 +2497,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -2520,8 +2520,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "1.0.0",
-				"object-visit": "1.0.1"
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
 			}
 		},
 		"color-convert": {
@@ -2551,7 +2551,7 @@
 			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
@@ -2584,10 +2584,10 @@
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.1",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6",
-				"typedarray": "0.0.6"
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
 			}
 		},
 		"console-browserify": {
@@ -2596,7 +2596,7 @@
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"dev": true,
 			"requires": {
-				"date-now": "0.1.4"
+				"date-now": "^0.1.4"
 			}
 		},
 		"constants-browserify": {
@@ -2611,7 +2611,7 @@
 			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.1"
 			}
 		},
 		"copy-concurrently": {
@@ -2620,12 +2620,12 @@
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 			"dev": true,
 			"requires": {
-				"aproba": "1.2.0",
-				"fs-write-stream-atomic": "1.0.10",
-				"iferr": "0.1.5",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"run-queue": "1.0.3"
+				"aproba": "^1.1.1",
+				"fs-write-stream-atomic": "^1.0.8",
+				"iferr": "^0.1.5",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.0"
 			}
 		},
 		"copy-descriptor": {
@@ -2652,8 +2652,8 @@
 			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"elliptic": "6.4.1"
+				"bn.js": "^4.1.0",
+				"elliptic": "^6.0.0"
 			}
 		},
 		"create-hash": {
@@ -2662,11 +2662,11 @@
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"inherits": "2.0.3",
-				"md5.js": "1.3.5",
-				"ripemd160": "2.0.2",
-				"sha.js": "2.4.11"
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
 			}
 		},
 		"create-hmac": {
@@ -2675,12 +2675,12 @@
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"create-hash": "1.2.0",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.2",
-				"safe-buffer": "5.1.2",
-				"sha.js": "2.4.11"
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"cross-spawn": {
@@ -2689,11 +2689,11 @@
 			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"dev": true,
 			"requires": {
-				"nice-try": "1.0.5",
-				"path-key": "2.0.1",
-				"semver": "5.6.0",
-				"shebang-command": "1.2.0",
-				"which": "1.3.1"
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"crypto-browserify": {
@@ -2702,17 +2702,17 @@
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"dev": true,
 			"requires": {
-				"browserify-cipher": "1.0.1",
-				"browserify-sign": "4.0.4",
-				"create-ecdh": "4.0.3",
-				"create-hash": "1.2.0",
-				"create-hmac": "1.1.7",
-				"diffie-hellman": "5.0.3",
-				"inherits": "2.0.3",
-				"pbkdf2": "3.0.17",
-				"public-encrypt": "4.0.3",
-				"randombytes": "2.0.6",
-				"randomfill": "1.0.4"
+				"browserify-cipher": "^1.0.0",
+				"browserify-sign": "^4.0.0",
+				"create-ecdh": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.0",
+				"diffie-hellman": "^5.0.0",
+				"inherits": "^2.0.1",
+				"pbkdf2": "^3.0.3",
+				"public-encrypt": "^4.0.0",
+				"randombytes": "^2.0.0",
+				"randomfill": "^1.0.3"
 			}
 		},
 		"css-select": {
@@ -2721,10 +2721,10 @@
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 			"dev": true,
 			"requires": {
-				"boolbase": "1.0.0",
-				"css-what": "2.1.2",
+				"boolbase": "~1.0.0",
+				"css-what": "2.1",
 				"domutils": "1.5.1",
-				"nth-check": "1.0.2"
+				"nth-check": "~1.0.1"
 			}
 		},
 		"css-what": {
@@ -2745,7 +2745,7 @@
 			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.4"
+				"cssom": "0.3.x"
 			}
 		},
 		"cyclist": {
@@ -2760,7 +2760,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"data-urls": {
@@ -2769,9 +2769,9 @@
 			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
 			"dev": true,
 			"requires": {
-				"abab": "2.0.0",
-				"whatwg-mimetype": "2.2.0",
-				"whatwg-url": "7.0.0"
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
 			}
 		},
 		"date-now": {
@@ -2786,7 +2786,7 @@
 			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 			"dev": true,
 			"requires": {
-				"ms": "2.1.1"
+				"ms": "^2.1.1"
 			}
 		},
 		"decamelize": {
@@ -2813,7 +2813,7 @@
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"dev": true,
 			"requires": {
-				"strip-bom": "2.0.0"
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"define-properties": {
@@ -2822,7 +2822,7 @@
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 			"dev": true,
 			"requires": {
-				"object-keys": "1.0.12"
+				"object-keys": "^1.0.12"
 			}
 		},
 		"define-property": {
@@ -2831,8 +2831,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "1.0.2",
-				"isobject": "3.0.1"
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -2841,7 +2841,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -2850,7 +2850,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -2859,9 +2859,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"kind-of": {
@@ -2884,8 +2884,8 @@
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.1"
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"detect-indent": {
@@ -2894,7 +2894,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"detect-newline": {
@@ -2915,9 +2915,9 @@
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"miller-rabin": "4.0.1",
-				"randombytes": "2.0.6"
+				"bn.js": "^4.1.0",
+				"miller-rabin": "^4.0.0",
+				"randombytes": "^2.0.0"
 			}
 		},
 		"discontinuous-range": {
@@ -2932,8 +2932,8 @@
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1.1.3",
-				"entities": "1.1.2"
+				"domelementtype": "~1.1.1",
+				"entities": "~1.1.1"
 			},
 			"dependencies": {
 				"domelementtype": {
@@ -2962,7 +2962,7 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "4.0.2"
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"domhandler": {
@@ -2971,7 +2971,7 @@
 			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1.2.1"
+				"domelementtype": "1"
 			}
 		},
 		"domutils": {
@@ -2980,8 +2980,8 @@
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
 			"dev": true,
 			"requires": {
-				"dom-serializer": "0.1.0",
-				"domelementtype": "1.2.1"
+				"dom-serializer": "0",
+				"domelementtype": "1"
 			}
 		},
 		"duplexify": {
@@ -2990,10 +2990,10 @@
 			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.1",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6",
-				"stream-shift": "1.0.0"
+				"end-of-stream": "^1.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0",
+				"stream-shift": "^1.0.0"
 			}
 		},
 		"ecc-jsbn": {
@@ -3002,8 +3002,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"dev": true,
 			"requires": {
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"electron-to-chromium": {
@@ -3018,13 +3018,13 @@
 			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0",
-				"hash.js": "1.1.5",
-				"hmac-drbg": "1.0.1",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.1",
-				"minimalistic-crypto-utils": "1.0.1"
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
 		"emojis-list": {
@@ -3039,7 +3039,7 @@
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.4.0"
 			}
 		},
 		"enhanced-resolve": {
@@ -3048,9 +3048,9 @@
 			"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.15",
-				"memory-fs": "0.4.1",
-				"tapable": "1.1.0"
+				"graceful-fs": "^4.1.2",
+				"memory-fs": "^0.4.0",
+				"tapable": "^1.0.0"
 			}
 		},
 		"entities": {
@@ -3065,25 +3065,25 @@
 			"integrity": "sha512-QLWx+krGK6iDNyR1KlH5YPZqxZCQaVF6ike1eDJAOg0HvSkSCVImPsdWaNw6v+VrnK92Kg8jIOYhuOSS9sBpyg==",
 			"dev": true,
 			"requires": {
-				"array.prototype.flat": "1.2.1",
-				"cheerio": "1.0.0-rc.2",
-				"function.prototype.name": "1.1.0",
-				"has": "1.0.3",
-				"is-boolean-object": "1.0.0",
-				"is-callable": "1.1.4",
-				"is-number-object": "1.0.3",
-				"is-string": "1.0.4",
-				"is-subset": "0.1.1",
-				"lodash.escape": "4.0.1",
-				"lodash.isequal": "4.5.0",
-				"object-inspect": "1.6.0",
-				"object-is": "1.0.1",
-				"object.assign": "4.1.0",
-				"object.entries": "1.0.4",
-				"object.values": "1.0.4",
-				"raf": "3.4.1",
-				"rst-selector-parser": "2.2.3",
-				"string.prototype.trim": "1.1.2"
+				"array.prototype.flat": "^1.2.1",
+				"cheerio": "^1.0.0-rc.2",
+				"function.prototype.name": "^1.1.0",
+				"has": "^1.0.3",
+				"is-boolean-object": "^1.0.0",
+				"is-callable": "^1.1.4",
+				"is-number-object": "^1.0.3",
+				"is-string": "^1.0.4",
+				"is-subset": "^0.1.1",
+				"lodash.escape": "^4.0.1",
+				"lodash.isequal": "^4.5.0",
+				"object-inspect": "^1.6.0",
+				"object-is": "^1.0.1",
+				"object.assign": "^4.1.0",
+				"object.entries": "^1.0.4",
+				"object.values": "^1.0.4",
+				"raf": "^3.4.0",
+				"rst-selector-parser": "^2.2.3",
+				"string.prototype.trim": "^1.1.2"
 			}
 		},
 		"enzyme-adapter-react-16": {
@@ -3092,13 +3092,13 @@
 			"integrity": "sha512-rDr0xlnnFPffAPYrvG97QYJaRl9unVDslKee33wTStsBEwZTkESX1H7VHGT5eUc6ifNzPgOJGvSh2zpHT4gXjA==",
 			"dev": true,
 			"requires": {
-				"enzyme-adapter-utils": "1.9.0",
-				"function.prototype.name": "1.1.0",
-				"object.assign": "4.1.0",
-				"object.values": "1.0.4",
-				"prop-types": "15.6.2",
-				"react-is": "16.6.1",
-				"react-test-renderer": "16.6.1"
+				"enzyme-adapter-utils": "^1.9.0",
+				"function.prototype.name": "^1.1.0",
+				"object.assign": "^4.1.0",
+				"object.values": "^1.0.4",
+				"prop-types": "^15.6.2",
+				"react-is": "^16.6.1",
+				"react-test-renderer": "^16.0.0-0"
 			}
 		},
 		"enzyme-adapter-utils": {
@@ -3107,10 +3107,10 @@
 			"integrity": "sha512-uMe4xw4l/Iloh2Fz+EO23XUYMEQXj5k/5ioLUXCNOUCI8Dml5XQMO9+QwUq962hBsY5qftfHHns+d990byWHvg==",
 			"dev": true,
 			"requires": {
-				"function.prototype.name": "1.1.0",
-				"object.assign": "4.1.0",
-				"prop-types": "15.6.2",
-				"semver": "5.6.0"
+				"function.prototype.name": "^1.1.0",
+				"object.assign": "^4.1.0",
+				"prop-types": "^15.6.2",
+				"semver": "^5.6.0"
 			}
 		},
 		"errno": {
@@ -3119,7 +3119,7 @@
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"dev": true,
 			"requires": {
-				"prr": "1.0.1"
+				"prr": "~1.0.1"
 			}
 		},
 		"error-ex": {
@@ -3128,7 +3128,7 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -3137,11 +3137,11 @@
 			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "1.2.0",
-				"function-bind": "1.1.1",
-				"has": "1.0.3",
-				"is-callable": "1.1.4",
-				"is-regex": "1.0.4"
+				"es-to-primitive": "^1.1.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.1",
+				"is-callable": "^1.1.3",
+				"is-regex": "^1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -3150,9 +3150,9 @@
 			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
 			"dev": true,
 			"requires": {
-				"is-callable": "1.1.4",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.2"
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
 			}
 		},
 		"escape-string-regexp": {
@@ -3167,11 +3167,11 @@
 			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
 			"dev": true,
 			"requires": {
-				"esprima": "3.1.3",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.6.1"
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -3195,8 +3195,8 @@
 			"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
 			"dev": true,
 			"requires": {
-				"esrecurse": "4.2.1",
-				"estraverse": "4.2.0"
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"esprima": {
@@ -3211,7 +3211,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.1.0"
 			}
 		},
 		"estraverse": {
@@ -3238,8 +3238,8 @@
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 			"dev": true,
 			"requires": {
-				"md5.js": "1.3.5",
-				"safe-buffer": "5.1.2"
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"exec-sh": {
@@ -3248,7 +3248,7 @@
 			"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
 			"dev": true,
 			"requires": {
-				"merge": "1.2.1"
+				"merge": "^1.2.0"
 			}
 		},
 		"execa": {
@@ -3257,13 +3257,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -3272,9 +3272,9 @@
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"shebang-command": "1.2.0",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				}
 			}
@@ -3291,7 +3291,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "0.1.1"
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
@@ -3300,7 +3300,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "2.2.4"
+				"fill-range": "^2.1.0"
 			}
 		},
 		"expect": {
@@ -3309,12 +3309,12 @@
 			"integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"jest-diff": "23.6.0",
-				"jest-get-type": "22.4.3",
-				"jest-matcher-utils": "23.6.0",
-				"jest-message-util": "23.4.0",
-				"jest-regex-util": "23.3.0"
+				"ansi-styles": "^3.2.0",
+				"jest-diff": "^23.6.0",
+				"jest-get-type": "^22.1.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-regex-util": "^23.3.0"
 			}
 		},
 		"extend": {
@@ -3329,8 +3329,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "1.0.0",
-				"is-extendable": "1.0.1"
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -3339,7 +3339,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -3350,7 +3350,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"extsprintf": {
@@ -3383,7 +3383,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "2.0.0"
+				"bser": "^2.0.0"
 			}
 		},
 		"filename-regex": {
@@ -3398,8 +3398,8 @@
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.3",
-				"minimatch": "3.0.4"
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
 			}
 		},
 		"fill-range": {
@@ -3408,11 +3408,11 @@
 			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 			"dev": true,
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "3.1.1",
-				"repeat-element": "1.1.3",
-				"repeat-string": "1.6.1"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^3.0.0",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			},
 			"dependencies": {
 				"isobject": {
@@ -3432,9 +3432,9 @@
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"dev": true,
 			"requires": {
-				"commondir": "1.0.1",
-				"make-dir": "1.3.0",
-				"pkg-dir": "2.0.0"
+				"commondir": "^1.0.1",
+				"make-dir": "^1.0.0",
+				"pkg-dir": "^2.0.0"
 			}
 		},
 		"find-up": {
@@ -3443,7 +3443,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"flush-write-stream": {
@@ -3452,8 +3452,8 @@
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6"
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.4"
 			}
 		},
 		"for-in": {
@@ -3468,7 +3468,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
 		},
 		"forever-agent": {
@@ -3483,9 +3483,9 @@
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"dev": true,
 			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.7",
-				"mime-types": "2.1.21"
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fragment-cache": {
@@ -3494,7 +3494,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "0.2.2"
+				"map-cache": "^0.2.2"
 			}
 		},
 		"from2": {
@@ -3503,8 +3503,8 @@
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6"
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
 			}
 		},
 		"fs-readdir-recursive": {
@@ -3519,10 +3519,10 @@
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.15",
-				"iferr": "0.1.5",
-				"imurmurhash": "0.1.4",
-				"readable-stream": "2.3.6"
+				"graceful-fs": "^4.1.2",
+				"iferr": "^0.1.5",
+				"imurmurhash": "^0.1.4",
+				"readable-stream": "1 || 2"
 			}
 		},
 		"fs.realpath": {
@@ -3538,8 +3538,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "2.11.1",
-				"node-pre-gyp": "0.10.0"
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -3572,12 +3572,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -3592,17 +3594,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3719,7 +3724,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3731,6 +3737,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3745,6 +3752,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
@@ -3752,12 +3760,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "5.1.1",
 						"yallist": "3.0.2"
@@ -3776,6 +3786,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3856,7 +3867,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3868,6 +3880,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -3989,6 +4002,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -4072,9 +4086,9 @@
 			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"function-bind": "1.1.1",
-				"is-callable": "1.1.4"
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"is-callable": "^1.1.3"
 			}
 		},
 		"get-caller-file": {
@@ -4101,7 +4115,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -4110,12 +4124,12 @@
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-base": {
@@ -4124,8 +4138,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"glob-parent": {
@@ -4134,7 +4148,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "2.0.1"
+				"is-glob": "^2.0.0"
 			}
 		},
 		"global-modules-path": {
@@ -4167,10 +4181,10 @@
 			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
 			"dev": true,
 			"requires": {
-				"async": "2.6.1",
-				"optimist": "0.6.1",
-				"source-map": "0.6.1",
-				"uglify-js": "3.4.9"
+				"async": "^2.5.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
 			},
 			"dependencies": {
 				"source-map": {
@@ -4193,8 +4207,8 @@
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.3.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has": {
@@ -4203,7 +4217,7 @@
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -4212,7 +4226,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -4233,9 +4247,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "2.0.6",
-				"has-values": "1.0.0",
-				"isobject": "3.0.1"
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
 			}
 		},
 		"has-values": {
@@ -4244,8 +4258,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -4254,7 +4268,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4263,7 +4277,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -4274,7 +4288,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -4285,8 +4299,8 @@
 			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.2"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"hash.js": {
@@ -4295,8 +4309,8 @@
 			"integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.1"
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
 			}
 		},
 		"hmac-drbg": {
@@ -4305,9 +4319,9 @@
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"dev": true,
 			"requires": {
-				"hash.js": "1.1.5",
-				"minimalistic-assert": "1.0.1",
-				"minimalistic-crypto-utils": "1.0.1"
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"home-or-tmp": {
@@ -4316,8 +4330,8 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
@@ -4332,7 +4346,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "1.0.5"
+				"whatwg-encoding": "^1.0.1"
 			}
 		},
 		"htmlparser2": {
@@ -4341,12 +4355,12 @@
 			"integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1.3.0",
-				"domhandler": "2.4.2",
-				"domutils": "1.5.1",
-				"entities": "1.1.2",
-				"inherits": "2.0.3",
-				"readable-stream": "3.0.6"
+				"domelementtype": "^1.3.0",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^3.0.6"
 			},
 			"dependencies": {
 				"domelementtype": {
@@ -4361,9 +4375,9 @@
 					"integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
 					"dev": true,
 					"requires": {
-						"inherits": "2.0.3",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				}
 			}
@@ -4374,9 +4388,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.15.2"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"https-browserify": {
@@ -4391,7 +4405,7 @@
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
 		"ieee754": {
@@ -4412,8 +4426,8 @@
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "2.0.0",
-				"resolve-cwd": "2.0.0"
+				"pkg-dir": "^2.0.0",
+				"resolve-cwd": "^2.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -4434,8 +4448,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -4456,7 +4470,7 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "1.4.0"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"invert-kv": {
@@ -4471,7 +4485,7 @@
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-arrayish": {
@@ -4486,7 +4500,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "1.12.0"
+				"binary-extensions": "^1.0.0"
 			}
 		},
 		"is-boolean-object": {
@@ -4507,7 +4521,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-callable": {
@@ -4522,7 +4536,7 @@
 			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "1.6.0"
+				"ci-info": "^1.5.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -4531,7 +4545,7 @@
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-date-object": {
@@ -4546,9 +4560,9 @@
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "0.1.6",
-				"is-data-descriptor": "0.1.4",
-				"kind-of": "5.1.0"
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4571,7 +4585,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -4592,7 +4606,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -4613,7 +4627,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"is-number": {
@@ -4622,7 +4636,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-number-object": {
@@ -4643,7 +4657,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			}
 		},
 		"is-posix-bracket": {
@@ -4664,7 +4678,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.3"
+				"has": "^1.0.1"
 			}
 		},
 		"is-stream": {
@@ -4691,7 +4705,7 @@
 			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
 			"dev": true,
 			"requires": {
-				"has-symbols": "1.0.0"
+				"has-symbols": "^1.0.0"
 			}
 		},
 		"is-typedarray": {
@@ -4742,17 +4756,17 @@
 			"integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
 			"dev": true,
 			"requires": {
-				"async": "2.6.1",
-				"fileset": "2.0.3",
-				"istanbul-lib-coverage": "1.2.1",
-				"istanbul-lib-hook": "1.2.2",
-				"istanbul-lib-instrument": "1.10.2",
-				"istanbul-lib-report": "1.1.5",
-				"istanbul-lib-source-maps": "1.2.6",
-				"istanbul-reports": "1.5.1",
-				"js-yaml": "3.12.0",
-				"mkdirp": "0.5.1",
-				"once": "1.4.0"
+				"async": "^2.1.4",
+				"fileset": "^2.0.2",
+				"istanbul-lib-coverage": "^1.2.1",
+				"istanbul-lib-hook": "^1.2.2",
+				"istanbul-lib-instrument": "^1.10.2",
+				"istanbul-lib-report": "^1.1.5",
+				"istanbul-lib-source-maps": "^1.2.6",
+				"istanbul-reports": "^1.5.1",
+				"js-yaml": "^3.7.0",
+				"mkdirp": "^0.5.1",
+				"once": "^1.4.0"
 			}
 		},
 		"istanbul-lib-coverage": {
@@ -4767,7 +4781,7 @@
 			"integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
 			"dev": true,
 			"requires": {
-				"append-transform": "0.4.0"
+				"append-transform": "^0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -4776,13 +4790,13 @@
 			"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "6.26.1",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"istanbul-lib-coverage": "1.2.1",
-				"semver": "5.6.0"
+				"babel-generator": "^6.18.0",
+				"babel-template": "^6.16.0",
+				"babel-traverse": "^6.18.0",
+				"babel-types": "^6.18.0",
+				"babylon": "^6.18.0",
+				"istanbul-lib-coverage": "^1.2.1",
+				"semver": "^5.3.0"
 			}
 		},
 		"istanbul-lib-report": {
@@ -4791,10 +4805,10 @@
 			"integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "1.2.1",
-				"mkdirp": "0.5.1",
-				"path-parse": "1.0.6",
-				"supports-color": "3.2.3"
+				"istanbul-lib-coverage": "^1.2.1",
+				"mkdirp": "^0.5.1",
+				"path-parse": "^1.0.5",
+				"supports-color": "^3.1.2"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -4809,7 +4823,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -4820,11 +4834,11 @@
 			"integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
 			"dev": true,
 			"requires": {
-				"debug": "3.2.6",
-				"istanbul-lib-coverage": "1.2.1",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"source-map": "0.5.7"
+				"debug": "^3.1.0",
+				"istanbul-lib-coverage": "^1.2.1",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.6.1",
+				"source-map": "^0.5.3"
 			}
 		},
 		"istanbul-reports": {
@@ -4833,7 +4847,7 @@
 			"integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
 			"dev": true,
 			"requires": {
-				"handlebars": "4.0.12"
+				"handlebars": "^4.0.3"
 			}
 		},
 		"jest": {
@@ -4842,8 +4856,8 @@
 			"integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
 			"dev": true,
 			"requires": {
-				"import-local": "1.0.0",
-				"jest-cli": "23.6.0"
+				"import-local": "^1.0.0",
+				"jest-cli": "^23.6.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4858,42 +4872,42 @@
 					"integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.1.0",
-						"chalk": "2.4.1",
-						"exit": "0.1.2",
-						"glob": "7.1.3",
-						"graceful-fs": "4.1.15",
-						"import-local": "1.0.0",
-						"is-ci": "1.2.1",
-						"istanbul-api": "1.3.7",
-						"istanbul-lib-coverage": "1.2.1",
-						"istanbul-lib-instrument": "1.10.2",
-						"istanbul-lib-source-maps": "1.2.6",
-						"jest-changed-files": "23.4.2",
-						"jest-config": "23.6.0",
-						"jest-environment-jsdom": "23.4.0",
-						"jest-get-type": "22.4.3",
-						"jest-haste-map": "23.6.0",
-						"jest-message-util": "23.4.0",
-						"jest-regex-util": "23.3.0",
-						"jest-resolve-dependencies": "23.6.0",
-						"jest-runner": "23.6.0",
-						"jest-runtime": "23.6.0",
-						"jest-snapshot": "23.6.0",
-						"jest-util": "23.4.0",
-						"jest-validate": "23.6.0",
-						"jest-watcher": "23.4.0",
-						"jest-worker": "23.2.0",
-						"micromatch": "2.3.11",
-						"node-notifier": "5.3.0",
-						"prompts": "0.1.14",
-						"realpath-native": "1.0.2",
-						"rimraf": "2.6.2",
-						"slash": "1.0.0",
-						"string-length": "2.0.0",
-						"strip-ansi": "4.0.0",
-						"which": "1.3.1",
-						"yargs": "11.1.0"
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"import-local": "^1.0.0",
+						"is-ci": "^1.0.10",
+						"istanbul-api": "^1.3.1",
+						"istanbul-lib-coverage": "^1.2.0",
+						"istanbul-lib-instrument": "^1.10.1",
+						"istanbul-lib-source-maps": "^1.2.4",
+						"jest-changed-files": "^23.4.2",
+						"jest-config": "^23.6.0",
+						"jest-environment-jsdom": "^23.4.0",
+						"jest-get-type": "^22.1.0",
+						"jest-haste-map": "^23.6.0",
+						"jest-message-util": "^23.4.0",
+						"jest-regex-util": "^23.3.0",
+						"jest-resolve-dependencies": "^23.6.0",
+						"jest-runner": "^23.6.0",
+						"jest-runtime": "^23.6.0",
+						"jest-snapshot": "^23.6.0",
+						"jest-util": "^23.4.0",
+						"jest-validate": "^23.6.0",
+						"jest-watcher": "^23.4.0",
+						"jest-worker": "^23.2.0",
+						"micromatch": "^2.3.11",
+						"node-notifier": "^5.2.1",
+						"prompts": "^0.1.9",
+						"realpath-native": "^1.0.0",
+						"rimraf": "^2.5.4",
+						"slash": "^1.0.0",
+						"string-length": "^2.0.0",
+						"strip-ansi": "^4.0.0",
+						"which": "^1.2.12",
+						"yargs": "^11.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4902,7 +4916,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -4913,7 +4927,7 @@
 			"integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
 			"dev": true,
 			"requires": {
-				"throat": "4.1.0"
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
@@ -4922,20 +4936,20 @@
 			"integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.26.3",
-				"babel-jest": "23.6.0",
-				"chalk": "2.4.1",
-				"glob": "7.1.3",
-				"jest-environment-jsdom": "23.4.0",
-				"jest-environment-node": "23.4.0",
-				"jest-get-type": "22.4.3",
-				"jest-jasmine2": "23.6.0",
-				"jest-regex-util": "23.3.0",
-				"jest-resolve": "23.6.0",
-				"jest-util": "23.4.0",
-				"jest-validate": "23.6.0",
-				"micromatch": "2.3.11",
-				"pretty-format": "23.6.0"
+				"babel-core": "^6.0.0",
+				"babel-jest": "^23.6.0",
+				"chalk": "^2.0.1",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^23.4.0",
+				"jest-environment-node": "^23.4.0",
+				"jest-get-type": "^22.1.0",
+				"jest-jasmine2": "^23.6.0",
+				"jest-regex-util": "^23.3.0",
+				"jest-resolve": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-validate": "^23.6.0",
+				"micromatch": "^2.3.11",
+				"pretty-format": "^23.6.0"
 			},
 			"dependencies": {
 				"babel-core": {
@@ -4944,25 +4958,25 @@
 					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-generator": "6.26.1",
-						"babel-helpers": "6.24.1",
-						"babel-messages": "6.23.0",
-						"babel-register": "6.26.0",
-						"babel-runtime": "6.26.0",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"convert-source-map": "1.6.0",
-						"debug": "2.6.9",
-						"json5": "0.5.1",
-						"lodash": "4.17.11",
-						"minimatch": "3.0.4",
-						"path-is-absolute": "1.0.1",
-						"private": "0.1.8",
-						"slash": "1.0.0",
-						"source-map": "0.5.7"
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
 					}
 				},
 				"debug": {
@@ -4988,10 +5002,10 @@
 			"integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"diff": "3.5.0",
-				"jest-get-type": "22.4.3",
-				"pretty-format": "23.6.0"
+				"chalk": "^2.0.1",
+				"diff": "^3.2.0",
+				"jest-get-type": "^22.1.0",
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-docblock": {
@@ -5000,7 +5014,7 @@
 			"integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
 			"dev": true,
 			"requires": {
-				"detect-newline": "2.1.0"
+				"detect-newline": "^2.1.0"
 			}
 		},
 		"jest-each": {
@@ -5009,8 +5023,8 @@
 			"integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"pretty-format": "23.6.0"
+				"chalk": "^2.0.1",
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-environment-jsdom": {
@@ -5019,9 +5033,9 @@
 			"integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
 			"dev": true,
 			"requires": {
-				"jest-mock": "23.2.0",
-				"jest-util": "23.4.0",
-				"jsdom": "11.12.0"
+				"jest-mock": "^23.2.0",
+				"jest-util": "^23.4.0",
+				"jsdom": "^11.5.1"
 			},
 			"dependencies": {
 				"acorn": {
@@ -5036,32 +5050,32 @@
 					"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
 					"dev": true,
 					"requires": {
-						"abab": "2.0.0",
-						"acorn": "5.7.3",
-						"acorn-globals": "4.3.0",
-						"array-equal": "1.0.0",
-						"cssom": "0.3.4",
-						"cssstyle": "1.1.1",
-						"data-urls": "1.1.0",
-						"domexception": "1.0.1",
-						"escodegen": "1.11.0",
-						"html-encoding-sniffer": "1.0.2",
-						"left-pad": "1.3.0",
-						"nwsapi": "2.0.9",
+						"abab": "^2.0.0",
+						"acorn": "^5.5.3",
+						"acorn-globals": "^4.1.0",
+						"array-equal": "^1.0.0",
+						"cssom": ">= 0.3.2 < 0.4.0",
+						"cssstyle": "^1.0.0",
+						"data-urls": "^1.0.0",
+						"domexception": "^1.0.1",
+						"escodegen": "^1.9.1",
+						"html-encoding-sniffer": "^1.0.2",
+						"left-pad": "^1.3.0",
+						"nwsapi": "^2.0.7",
 						"parse5": "4.0.0",
-						"pn": "1.1.0",
-						"request": "2.88.0",
-						"request-promise-native": "1.0.5",
-						"sax": "1.2.4",
-						"symbol-tree": "3.2.2",
-						"tough-cookie": "2.4.3",
-						"w3c-hr-time": "1.0.1",
-						"webidl-conversions": "4.0.2",
-						"whatwg-encoding": "1.0.5",
-						"whatwg-mimetype": "2.2.0",
-						"whatwg-url": "6.5.0",
-						"ws": "5.2.2",
-						"xml-name-validator": "3.0.0"
+						"pn": "^1.1.0",
+						"request": "^2.87.0",
+						"request-promise-native": "^1.0.5",
+						"sax": "^1.2.4",
+						"symbol-tree": "^3.2.2",
+						"tough-cookie": "^2.3.4",
+						"w3c-hr-time": "^1.0.1",
+						"webidl-conversions": "^4.0.2",
+						"whatwg-encoding": "^1.0.3",
+						"whatwg-mimetype": "^2.1.0",
+						"whatwg-url": "^6.4.1",
+						"ws": "^5.2.0",
+						"xml-name-validator": "^3.0.0"
 					}
 				},
 				"parse5": {
@@ -5076,9 +5090,9 @@
 					"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
 					"dev": true,
 					"requires": {
-						"lodash.sortby": "4.7.0",
-						"tr46": "1.0.1",
-						"webidl-conversions": "4.0.2"
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
 					}
 				},
 				"ws": {
@@ -5087,7 +5101,7 @@
 					"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
 					"dev": true,
 					"requires": {
-						"async-limiter": "1.0.0"
+						"async-limiter": "~1.0.0"
 					}
 				}
 			}
@@ -5098,8 +5112,8 @@
 			"integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
 			"dev": true,
 			"requires": {
-				"jest-mock": "23.2.0",
-				"jest-util": "23.4.0"
+				"jest-mock": "^23.2.0",
+				"jest-util": "^23.4.0"
 			}
 		},
 		"jest-get-type": {
@@ -5114,14 +5128,14 @@
 			"integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
 			"dev": true,
 			"requires": {
-				"fb-watchman": "2.0.0",
-				"graceful-fs": "4.1.15",
-				"invariant": "2.2.4",
-				"jest-docblock": "23.2.0",
-				"jest-serializer": "23.0.1",
-				"jest-worker": "23.2.0",
-				"micromatch": "2.3.11",
-				"sane": "2.5.2"
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.11",
+				"invariant": "^2.2.4",
+				"jest-docblock": "^23.2.0",
+				"jest-serializer": "^23.0.1",
+				"jest-worker": "^23.2.0",
+				"micromatch": "^2.3.11",
+				"sane": "^2.0.0"
 			}
 		},
 		"jest-jasmine2": {
@@ -5130,18 +5144,18 @@
 			"integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
 			"dev": true,
 			"requires": {
-				"babel-traverse": "6.26.0",
-				"chalk": "2.4.1",
-				"co": "4.6.0",
-				"expect": "23.6.0",
-				"is-generator-fn": "1.0.0",
-				"jest-diff": "23.6.0",
-				"jest-each": "23.6.0",
-				"jest-matcher-utils": "23.6.0",
-				"jest-message-util": "23.4.0",
-				"jest-snapshot": "23.6.0",
-				"jest-util": "23.4.0",
-				"pretty-format": "23.6.0"
+				"babel-traverse": "^6.0.0",
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^23.6.0",
+				"is-generator-fn": "^1.0.0",
+				"jest-diff": "^23.6.0",
+				"jest-each": "^23.6.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-snapshot": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-leak-detector": {
@@ -5150,7 +5164,7 @@
 			"integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "23.6.0"
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-matcher-utils": {
@@ -5159,9 +5173,9 @@
 			"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"jest-get-type": "22.4.3",
-				"pretty-format": "23.6.0"
+				"chalk": "^2.0.1",
+				"jest-get-type": "^22.1.0",
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-message-util": {
@@ -5170,11 +5184,11 @@
 			"integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0",
-				"chalk": "2.4.1",
-				"micromatch": "2.3.11",
-				"slash": "1.0.0",
-				"stack-utils": "1.0.1"
+				"@babel/code-frame": "^7.0.0-beta.35",
+				"chalk": "^2.0.1",
+				"micromatch": "^2.3.11",
+				"slash": "^1.0.0",
+				"stack-utils": "^1.0.1"
 			}
 		},
 		"jest-mock": {
@@ -5195,9 +5209,9 @@
 			"integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
 			"dev": true,
 			"requires": {
-				"browser-resolve": "1.11.3",
-				"chalk": "2.4.1",
-				"realpath-native": "1.0.2"
+				"browser-resolve": "^1.11.3",
+				"chalk": "^2.0.1",
+				"realpath-native": "^1.0.0"
 			}
 		},
 		"jest-resolve-dependencies": {
@@ -5206,8 +5220,8 @@
 			"integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "23.3.0",
-				"jest-snapshot": "23.6.0"
+				"jest-regex-util": "^23.3.0",
+				"jest-snapshot": "^23.6.0"
 			}
 		},
 		"jest-runner": {
@@ -5216,19 +5230,19 @@
 			"integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
 			"dev": true,
 			"requires": {
-				"exit": "0.1.2",
-				"graceful-fs": "4.1.15",
-				"jest-config": "23.6.0",
-				"jest-docblock": "23.2.0",
-				"jest-haste-map": "23.6.0",
-				"jest-jasmine2": "23.6.0",
-				"jest-leak-detector": "23.6.0",
-				"jest-message-util": "23.4.0",
-				"jest-runtime": "23.6.0",
-				"jest-util": "23.4.0",
-				"jest-worker": "23.2.0",
-				"source-map-support": "0.5.9",
-				"throat": "4.1.0"
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^23.6.0",
+				"jest-docblock": "^23.2.0",
+				"jest-haste-map": "^23.6.0",
+				"jest-jasmine2": "^23.6.0",
+				"jest-leak-detector": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-runtime": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-worker": "^23.2.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -5243,8 +5257,8 @@
 					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 					"dev": true,
 					"requires": {
-						"buffer-from": "1.1.1",
-						"source-map": "0.6.1"
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
 					}
 				}
 			}
@@ -5255,27 +5269,27 @@
 			"integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.26.3",
-				"babel-plugin-istanbul": "4.1.6",
-				"chalk": "2.4.1",
-				"convert-source-map": "1.6.0",
-				"exit": "0.1.2",
-				"fast-json-stable-stringify": "2.0.0",
-				"graceful-fs": "4.1.15",
-				"jest-config": "23.6.0",
-				"jest-haste-map": "23.6.0",
-				"jest-message-util": "23.4.0",
-				"jest-regex-util": "23.3.0",
-				"jest-resolve": "23.6.0",
-				"jest-snapshot": "23.6.0",
-				"jest-util": "23.4.0",
-				"jest-validate": "23.6.0",
-				"micromatch": "2.3.11",
-				"realpath-native": "1.0.2",
-				"slash": "1.0.0",
+				"babel-core": "^6.0.0",
+				"babel-plugin-istanbul": "^4.1.6",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"exit": "^0.1.2",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^23.6.0",
+				"jest-haste-map": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-regex-util": "^23.3.0",
+				"jest-resolve": "^23.6.0",
+				"jest-snapshot": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-validate": "^23.6.0",
+				"micromatch": "^2.3.11",
+				"realpath-native": "^1.0.0",
+				"slash": "^1.0.0",
 				"strip-bom": "3.0.0",
-				"write-file-atomic": "2.3.0",
-				"yargs": "11.1.0"
+				"write-file-atomic": "^2.1.0",
+				"yargs": "^11.0.0"
 			},
 			"dependencies": {
 				"babel-core": {
@@ -5284,25 +5298,25 @@
 					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-generator": "6.26.1",
-						"babel-helpers": "6.24.1",
-						"babel-messages": "6.23.0",
-						"babel-register": "6.26.0",
-						"babel-runtime": "6.26.0",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"convert-source-map": "1.6.0",
-						"debug": "2.6.9",
-						"json5": "0.5.1",
-						"lodash": "4.17.11",
-						"minimatch": "3.0.4",
-						"path-is-absolute": "1.0.1",
-						"private": "0.1.8",
-						"slash": "1.0.0",
-						"source-map": "0.5.7"
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
 					}
 				},
 				"debug": {
@@ -5340,16 +5354,16 @@
 			"integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
 			"dev": true,
 			"requires": {
-				"babel-types": "6.26.0",
-				"chalk": "2.4.1",
-				"jest-diff": "23.6.0",
-				"jest-matcher-utils": "23.6.0",
-				"jest-message-util": "23.4.0",
-				"jest-resolve": "23.6.0",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"pretty-format": "23.6.0",
-				"semver": "5.6.0"
+				"babel-types": "^6.0.0",
+				"chalk": "^2.0.1",
+				"jest-diff": "^23.6.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-resolve": "^23.6.0",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^23.6.0",
+				"semver": "^5.5.0"
 			}
 		},
 		"jest-util": {
@@ -5358,14 +5372,14 @@
 			"integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
 			"dev": true,
 			"requires": {
-				"callsites": "2.0.0",
-				"chalk": "2.4.1",
-				"graceful-fs": "4.1.15",
-				"is-ci": "1.2.1",
-				"jest-message-util": "23.4.0",
-				"mkdirp": "0.5.1",
-				"slash": "1.0.0",
-				"source-map": "0.6.1"
+				"callsites": "^2.0.0",
+				"chalk": "^2.0.1",
+				"graceful-fs": "^4.1.11",
+				"is-ci": "^1.0.10",
+				"jest-message-util": "^23.4.0",
+				"mkdirp": "^0.5.1",
+				"slash": "^1.0.0",
+				"source-map": "^0.6.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -5382,10 +5396,10 @@
 			"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"jest-get-type": "22.4.3",
-				"leven": "2.1.0",
-				"pretty-format": "23.6.0"
+				"chalk": "^2.0.1",
+				"jest-get-type": "^22.1.0",
+				"leven": "^2.1.0",
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-watcher": {
@@ -5394,9 +5408,9 @@
 			"integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "3.1.0",
-				"chalk": "2.4.1",
-				"string-length": "2.0.0"
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"string-length": "^2.0.0"
 			}
 		},
 		"jest-worker": {
@@ -5405,7 +5419,7 @@
 			"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
 			"dev": true,
 			"requires": {
-				"merge-stream": "1.0.1"
+				"merge-stream": "^1.0.1"
 			}
 		},
 		"js-levenshtein": {
@@ -5426,8 +5440,8 @@
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -5490,7 +5504,7 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.6"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"kleur": {
@@ -5505,7 +5519,7 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"dev": true,
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"left-pad": {
@@ -5526,8 +5540,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"load-json-file": {
@@ -5536,11 +5550,11 @@
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.15",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			},
 			"dependencies": {
 				"parse-json": {
@@ -5549,7 +5563,7 @@
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.2"
+						"error-ex": "^1.2.0"
 					}
 				}
 			}
@@ -5566,9 +5580,9 @@
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 			"dev": true,
 			"requires": {
-				"big.js": "3.2.0",
-				"emojis-list": "2.1.0",
-				"json5": "0.5.1"
+				"big.js": "^3.1.3",
+				"emojis-list": "^2.0.0",
+				"json5": "^0.5.0"
 			}
 		},
 		"locate-path": {
@@ -5577,8 +5591,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
@@ -5623,7 +5637,7 @@
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"dev": true,
 			"requires": {
-				"js-tokens": "4.0.0"
+				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
 		"lru-cache": {
@@ -5632,8 +5646,8 @@
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"make-dir": {
@@ -5642,7 +5656,7 @@
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"dev": true,
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -5659,7 +5673,7 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.4"
+				"tmpl": "1.0.x"
 			}
 		},
 		"map-age-cleaner": {
@@ -5668,7 +5682,7 @@
 			"integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
 			"dev": true,
 			"requires": {
-				"p-defer": "1.0.0"
+				"p-defer": "^1.0.0"
 			}
 		},
 		"map-cache": {
@@ -5683,7 +5697,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "1.0.1"
+				"object-visit": "^1.0.0"
 			}
 		},
 		"math-random": {
@@ -5698,9 +5712,9 @@
 			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
 			"dev": true,
 			"requires": {
-				"hash-base": "3.0.4",
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.2"
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"mem": {
@@ -5709,7 +5723,7 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"memory-fs": {
@@ -5718,8 +5732,8 @@
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"dev": true,
 			"requires": {
-				"errno": "0.1.7",
-				"readable-stream": "2.3.6"
+				"errno": "^0.1.3",
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"merge": {
@@ -5734,7 +5748,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.6"
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"micromatch": {
@@ -5743,19 +5757,19 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
 			}
 		},
 		"miller-rabin": {
@@ -5764,8 +5778,8 @@
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0"
+				"bn.js": "^4.0.0",
+				"brorand": "^1.0.1"
 			}
 		},
 		"mime-db": {
@@ -5780,7 +5794,7 @@
 			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.37.0"
+				"mime-db": "~1.37.0"
 			}
 		},
 		"mimic-fn": {
@@ -5807,7 +5821,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -5822,16 +5836,16 @@
 			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
 			"dev": true,
 			"requires": {
-				"concat-stream": "1.6.2",
-				"duplexify": "3.6.1",
-				"end-of-stream": "1.4.1",
-				"flush-write-stream": "1.0.3",
-				"from2": "2.3.0",
-				"parallel-transform": "1.1.0",
-				"pump": "2.0.1",
-				"pumpify": "1.5.1",
-				"stream-each": "1.2.3",
-				"through2": "2.0.5"
+				"concat-stream": "^1.5.0",
+				"duplexify": "^3.4.2",
+				"end-of-stream": "^1.1.0",
+				"flush-write-stream": "^1.0.0",
+				"from2": "^2.1.0",
+				"parallel-transform": "^1.1.0",
+				"pump": "^2.0.1",
+				"pumpify": "^1.3.3",
+				"stream-each": "^1.1.0",
+				"through2": "^2.0.0"
 			}
 		},
 		"mixin-deep": {
@@ -5840,8 +5854,8 @@
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2",
-				"is-extendable": "1.0.1"
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -5850,7 +5864,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -5876,12 +5890,12 @@
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 			"dev": true,
 			"requires": {
-				"aproba": "1.2.0",
-				"copy-concurrently": "1.0.5",
-				"fs-write-stream-atomic": "1.0.10",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"run-queue": "1.0.3"
+				"aproba": "^1.1.1",
+				"copy-concurrently": "^1.0.0",
+				"fs-write-stream-atomic": "^1.0.8",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.3"
 			}
 		},
 		"ms": {
@@ -5903,17 +5917,17 @@
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"fragment-cache": "0.2.1",
-				"is-windows": "1.0.2",
-				"kind-of": "6.0.2",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -5948,11 +5962,11 @@
 			"integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
 			"dev": true,
 			"requires": {
-				"moo": "0.4.3",
-				"nomnom": "1.6.2",
-				"railroad-diagrams": "1.0.0",
+				"moo": "^0.4.3",
+				"nomnom": "~1.6.2",
+				"railroad-diagrams": "^1.0.0",
 				"randexp": "0.4.6",
-				"semver": "5.6.0"
+				"semver": "^5.4.1"
 			}
 		},
 		"neo-async": {
@@ -5979,28 +5993,28 @@
 			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"dev": true,
 			"requires": {
-				"assert": "1.4.1",
-				"browserify-zlib": "0.2.0",
-				"buffer": "4.9.1",
-				"console-browserify": "1.1.0",
-				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.12.0",
-				"domain-browser": "1.2.0",
-				"events": "1.1.1",
-				"https-browserify": "1.0.0",
-				"os-browserify": "0.3.0",
+				"assert": "^1.1.1",
+				"browserify-zlib": "^0.2.0",
+				"buffer": "^4.3.0",
+				"console-browserify": "^1.1.0",
+				"constants-browserify": "^1.0.0",
+				"crypto-browserify": "^3.11.0",
+				"domain-browser": "^1.1.1",
+				"events": "^1.0.0",
+				"https-browserify": "^1.0.0",
+				"os-browserify": "^0.3.0",
 				"path-browserify": "0.0.0",
-				"process": "0.11.10",
-				"punycode": "1.4.1",
-				"querystring-es3": "0.2.1",
-				"readable-stream": "2.3.6",
-				"stream-browserify": "2.0.1",
-				"stream-http": "2.8.3",
-				"string_decoder": "1.1.1",
-				"timers-browserify": "2.0.10",
+				"process": "^0.11.10",
+				"punycode": "^1.2.4",
+				"querystring-es3": "^0.2.0",
+				"readable-stream": "^2.3.3",
+				"stream-browserify": "^2.0.1",
+				"stream-http": "^2.7.2",
+				"string_decoder": "^1.0.0",
+				"timers-browserify": "^2.0.4",
 				"tty-browserify": "0.0.0",
-				"url": "0.11.0",
-				"util": "0.10.4",
+				"url": "^0.11.0",
+				"util": "^0.10.3",
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
@@ -6018,10 +6032,10 @@
 			"integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
 			"dev": true,
 			"requires": {
-				"growly": "1.3.0",
-				"semver": "5.6.0",
-				"shellwords": "0.1.1",
-				"which": "1.3.1"
+				"growly": "^1.3.0",
+				"semver": "^5.5.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
 			}
 		},
 		"node-releases": {
@@ -6030,7 +6044,7 @@
 			"integrity": "sha512-ZaZWMsbuDcetpHmYeKWPO6e63pSXLb50M7lJgCbcM2nC/nQC3daNifmtp5a2kp7EWwYfhuvH6zLPWkrF8IiDdw==",
 			"dev": true,
 			"requires": {
-				"semver": "5.6.0"
+				"semver": "^5.3.0"
 			}
 		},
 		"nomnom": {
@@ -6039,8 +6053,8 @@
 			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
 			"dev": true,
 			"requires": {
-				"colors": "0.5.1",
-				"underscore": "1.4.4"
+				"colors": "0.5.x",
+				"underscore": "~1.4.4"
 			}
 		},
 		"normalize-package-data": {
@@ -6049,10 +6063,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.7.1",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.6.0",
-				"validate-npm-package-license": "3.0.4"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -6061,7 +6075,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -6070,7 +6084,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"nth-check": {
@@ -6079,7 +6093,7 @@
 			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
 			"dev": true,
 			"requires": {
-				"boolbase": "1.0.0"
+				"boolbase": "~1.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -6112,9 +6126,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "0.1.1",
-				"define-property": "0.2.5",
-				"kind-of": "3.2.2"
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
 			},
 			"dependencies": {
 				"define-property": {
@@ -6123,7 +6137,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -6157,7 +6171,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.0"
 			}
 		},
 		"object.assign": {
@@ -6166,10 +6180,10 @@
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"function-bind": "1.1.1",
-				"has-symbols": "1.0.0",
-				"object-keys": "1.0.12"
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
 			}
 		},
 		"object.entries": {
@@ -6178,10 +6192,10 @@
 			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"es-abstract": "1.12.0",
-				"function-bind": "1.1.1",
-				"has": "1.0.3"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.6.1",
+				"function-bind": "^1.1.0",
+				"has": "^1.0.1"
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -6190,8 +6204,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"es-abstract": "1.12.0"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
 			}
 		},
 		"object.omit": {
@@ -6200,8 +6214,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
@@ -6210,7 +6224,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			}
 		},
 		"object.values": {
@@ -6219,10 +6233,10 @@
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"es-abstract": "1.12.0",
-				"function-bind": "1.1.1",
-				"has": "1.0.3"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.6.1",
+				"function-bind": "^1.1.0",
+				"has": "^1.0.1"
 			}
 		},
 		"once": {
@@ -6231,7 +6245,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"optimist": {
@@ -6240,8 +6254,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8",
-				"wordwrap": "0.0.3"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -6258,12 +6272,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			}
 		},
 		"os-browserify": {
@@ -6284,9 +6298,9 @@
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"dev": true,
 			"requires": {
-				"execa": "0.7.0",
-				"lcid": "1.0.0",
-				"mem": "1.1.0"
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -6301,9 +6315,9 @@
 			"integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.15",
-				"is-plain-obj": "1.1.0",
-				"mkdirp": "0.5.1"
+				"graceful-fs": "^4.1.11",
+				"is-plain-obj": "^1.1.0",
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"p-defer": {
@@ -6330,7 +6344,7 @@
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"dev": true,
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
@@ -6339,7 +6353,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "1.3.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-try": {
@@ -6360,9 +6374,9 @@
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 			"dev": true,
 			"requires": {
-				"cyclist": "0.2.2",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6"
+				"cyclist": "~0.2.2",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.1.5"
 			}
 		},
 		"parse-asn1": {
@@ -6371,11 +6385,11 @@
 			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"dev": true,
 			"requires": {
-				"asn1.js": "4.10.1",
-				"browserify-aes": "1.2.0",
-				"create-hash": "1.2.0",
-				"evp_bytestokey": "1.0.3",
-				"pbkdf2": "3.0.17"
+				"asn1.js": "^4.0.0",
+				"browserify-aes": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3"
 			}
 		},
 		"parse-glob": {
@@ -6384,10 +6398,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"parse5": {
@@ -6396,7 +6410,7 @@
 			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
 			"dev": true,
 			"requires": {
-				"@types/node": "10.12.5"
+				"@types/node": "*"
 			}
 		},
 		"pascalcase": {
@@ -6447,9 +6461,9 @@
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.15",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"pbkdf2": {
@@ -6458,11 +6472,11 @@
 			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
 			"dev": true,
 			"requires": {
-				"create-hash": "1.2.0",
-				"create-hmac": "1.1.7",
-				"ripemd160": "2.0.2",
-				"safe-buffer": "5.1.2",
-				"sha.js": "2.4.11"
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"performance-now": {
@@ -6489,7 +6503,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -6498,7 +6512,7 @@
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^2.1.0"
 			}
 		},
 		"pn": {
@@ -6531,8 +6545,8 @@
 			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "3.0.0",
-				"ansi-styles": "3.2.1"
+				"ansi-regex": "^3.0.0",
+				"ansi-styles": "^3.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6573,8 +6587,8 @@
 			"integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
 			"dev": true,
 			"requires": {
-				"kleur": "2.0.2",
-				"sisteransi": "0.1.1"
+				"kleur": "^2.0.1",
+				"sisteransi": "^0.1.1"
 			}
 		},
 		"prop-types": {
@@ -6583,8 +6597,8 @@
 			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "1.4.0",
-				"object-assign": "4.1.1"
+				"loose-envify": "^1.3.1",
+				"object-assign": "^4.1.1"
 			}
 		},
 		"prr": {
@@ -6611,12 +6625,12 @@
 			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.2.0",
-				"parse-asn1": "5.1.1",
-				"randombytes": "2.0.6",
-				"safe-buffer": "5.1.2"
+				"bn.js": "^4.1.0",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"parse-asn1": "^5.0.0",
+				"randombytes": "^2.0.1",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"pump": {
@@ -6625,8 +6639,8 @@
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.1",
-				"once": "1.4.0"
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
 			}
 		},
 		"pumpify": {
@@ -6635,9 +6649,9 @@
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
 			"dev": true,
 			"requires": {
-				"duplexify": "3.6.1",
-				"inherits": "2.0.3",
-				"pump": "2.0.1"
+				"duplexify": "^3.6.0",
+				"inherits": "^2.0.3",
+				"pump": "^2.0.0"
 			}
 		},
 		"punycode": {
@@ -6670,7 +6684,7 @@
 			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
 			"dev": true,
 			"requires": {
-				"performance-now": "2.1.0"
+				"performance-now": "^2.1.0"
 			}
 		},
 		"railroad-diagrams": {
@@ -6686,7 +6700,7 @@
 			"dev": true,
 			"requires": {
 				"discontinuous-range": "1.0.0",
-				"ret": "0.1.15"
+				"ret": "~0.1.10"
 			}
 		},
 		"randomatic": {
@@ -6695,9 +6709,9 @@
 			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
 			"dev": true,
 			"requires": {
-				"is-number": "4.0.0",
-				"kind-of": "6.0.2",
-				"math-random": "1.0.1"
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -6720,7 +6734,7 @@
 			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"randomfill": {
@@ -6729,8 +6743,8 @@
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 			"dev": true,
 			"requires": {
-				"randombytes": "2.0.6",
-				"safe-buffer": "5.1.2"
+				"randombytes": "^2.0.5",
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"react": {
@@ -6739,10 +6753,10 @@
 			"integrity": "sha512-OtawJThYlvRgm9BXK+xTL7BIlDx8vv21j+fbQDjRRUyok6y7NyjlweGorielTahLZHYIdKUoK2Dp9ByVWuMqxw==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "1.4.0",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.2",
-				"scheduler": "0.11.0"
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.11.0"
 			}
 		},
 		"react-dom": {
@@ -6751,10 +6765,10 @@
 			"integrity": "sha512-zm+wBuEMGm009Wt1uE4Zw5KcXOW7qC4E/xW/fpJsCsbOco4U/R84u+DzzO/S4SYSdNBcqcaulcp4w3FXl8pImw==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "1.4.0",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.2",
-				"scheduler": "0.11.0"
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.11.0"
 			}
 		},
 		"react-is": {
@@ -6769,10 +6783,10 @@
 			"integrity": "sha512-sgZwJZYIgQptRi2qk5+gB8FBQGk4gLSs0gmKZPMfhd3dLkdxIUwVLHteLN3Bnj4LokIZd3U+V2NEJUqeV2PT2w==",
 			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.2",
-				"react-is": "16.6.1",
-				"scheduler": "0.11.0"
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"react-is": "^16.6.1",
+				"scheduler": "^0.11.0"
 			}
 		},
 		"read-pkg": {
@@ -6781,9 +6795,9 @@
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "1.1.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "1.1.0"
+				"load-json-file": "^1.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^1.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -6792,8 +6806,8 @@
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -6802,8 +6816,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-exists": {
@@ -6812,7 +6826,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -6823,13 +6837,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readdirp": {
@@ -6838,9 +6852,9 @@
 			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.15",
-				"micromatch": "3.1.10",
-				"readable-stream": "2.3.6"
+				"graceful-fs": "^4.1.11",
+				"micromatch": "^3.1.10",
+				"readable-stream": "^2.0.2"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -6861,16 +6875,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.3",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -6879,7 +6893,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -6899,13 +6913,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -6914,7 +6928,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -6923,7 +6937,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -6932,7 +6946,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -6941,7 +6955,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -6952,7 +6966,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -6961,7 +6975,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -6972,9 +6986,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -6991,14 +7005,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -7007,7 +7021,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -7016,7 +7030,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -7027,10 +7041,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -7039,7 +7053,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -7050,7 +7064,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -7059,7 +7073,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -7068,9 +7082,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"is-number": {
@@ -7079,7 +7093,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -7088,7 +7102,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -7105,19 +7119,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.13",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"ms": {
@@ -7134,7 +7148,7 @@
 			"integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "1.0.0"
+				"util.promisify": "^1.0.0"
 			}
 		},
 		"regenerate": {
@@ -7149,7 +7163,7 @@
 			"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
 			"dev": true,
 			"requires": {
-				"regenerate": "1.4.0"
+				"regenerate": "^1.4.0"
 			}
 		},
 		"regenerator-runtime": {
@@ -7164,7 +7178,7 @@
 			"integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
 			"dev": true,
 			"requires": {
-				"private": "0.1.8"
+				"private": "^0.1.6"
 			}
 		},
 		"regex-cache": {
@@ -7173,7 +7187,7 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"regex-not": {
@@ -7182,8 +7196,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2",
-				"safe-regex": "1.1.0"
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpu-core": {
@@ -7192,12 +7206,12 @@
 			"integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
 			"dev": true,
 			"requires": {
-				"regenerate": "1.4.0",
-				"regenerate-unicode-properties": "7.0.0",
-				"regjsgen": "0.4.0",
-				"regjsparser": "0.3.0",
-				"unicode-match-property-ecmascript": "1.0.4",
-				"unicode-match-property-value-ecmascript": "1.0.2"
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^7.0.0",
+				"regjsgen": "^0.4.0",
+				"regjsparser": "^0.3.0",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.0.2"
 			}
 		},
 		"regjsgen": {
@@ -7212,7 +7226,7 @@
 			"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
 			"dev": true,
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -7247,7 +7261,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"request": {
@@ -7256,26 +7270,26 @@
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.8.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.7",
-				"extend": "3.0.2",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.3",
-				"har-validator": "5.1.0",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.21",
-				"oauth-sign": "0.9.0",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.4.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.3.2"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"request-promise-core": {
@@ -7284,7 +7298,7 @@
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.11"
+				"lodash": "^4.13.1"
 			}
 		},
 		"request-promise-native": {
@@ -7294,8 +7308,8 @@
 			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.4.3"
+				"stealthy-require": "^1.1.0",
+				"tough-cookie": ">=2.3.3"
 			}
 		},
 		"require-directory": {
@@ -7316,7 +7330,7 @@
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 			"dev": true,
 			"requires": {
-				"path-parse": "1.0.6"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"resolve-cwd": {
@@ -7325,7 +7339,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "3.0.0"
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"resolve-from": {
@@ -7352,7 +7366,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.3"
+				"glob": "^7.0.5"
 			}
 		},
 		"ripemd160": {
@@ -7361,8 +7375,8 @@
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 			"dev": true,
 			"requires": {
-				"hash-base": "3.0.4",
-				"inherits": "2.0.3"
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"rst-selector-parser": {
@@ -7371,8 +7385,8 @@
 			"integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
 			"dev": true,
 			"requires": {
-				"lodash.flattendeep": "4.4.0",
-				"nearley": "2.15.1"
+				"lodash.flattendeep": "^4.4.0",
+				"nearley": "^2.7.10"
 			}
 		},
 		"rsvp": {
@@ -7387,7 +7401,7 @@
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 			"dev": true,
 			"requires": {
-				"aproba": "1.2.0"
+				"aproba": "^1.1.1"
 			}
 		},
 		"safe-buffer": {
@@ -7402,7 +7416,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "0.1.15"
+				"ret": "~0.1.10"
 			}
 		},
 		"safer-buffer": {
@@ -7417,15 +7431,15 @@
 			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 			"dev": true,
 			"requires": {
-				"anymatch": "2.0.0",
-				"capture-exit": "1.2.0",
-				"exec-sh": "0.2.2",
-				"fb-watchman": "2.0.0",
-				"fsevents": "1.2.4",
-				"micromatch": "3.1.10",
-				"minimist": "1.2.0",
-				"walker": "1.0.7",
-				"watch": "0.18.0"
+				"anymatch": "^2.0.0",
+				"capture-exit": "^1.2.0",
+				"exec-sh": "^0.2.0",
+				"fb-watchman": "^2.0.0",
+				"fsevents": "^1.2.3",
+				"micromatch": "^3.1.4",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5",
+				"watch": "~0.18.0"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -7446,16 +7460,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.3",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -7464,7 +7478,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -7484,13 +7498,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -7499,7 +7513,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -7508,7 +7522,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -7517,7 +7531,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -7526,7 +7540,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -7537,7 +7551,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -7546,7 +7560,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -7557,9 +7571,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -7576,14 +7590,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -7592,7 +7606,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -7601,7 +7615,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -7612,10 +7626,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -7624,7 +7638,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -7635,7 +7649,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -7644,7 +7658,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -7653,9 +7667,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"is-number": {
@@ -7664,7 +7678,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -7673,7 +7687,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -7690,19 +7704,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.13",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"minimist": {
@@ -7731,8 +7745,8 @@
 			"integrity": "sha512-MAYbBfmiEHxF0W+c4CxMpEqMYK+rYF584VP/qMKSiHM6lTkBKKYOJaDiSILpJHla6hBOsVd6GucPL46o2Uq3sg==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "1.4.0",
-				"object-assign": "4.1.1"
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1"
 			}
 		},
 		"schema-utils": {
@@ -7741,8 +7755,8 @@
 			"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
 			"dev": true,
 			"requires": {
-				"ajv": "6.5.5",
-				"ajv-keywords": "3.2.0"
+				"ajv": "^6.1.0",
+				"ajv-keywords": "^3.1.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -7751,10 +7765,10 @@
 					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "2.0.1",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.4.1",
-						"uri-js": "4.2.2"
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
 					}
 				},
 				"fast-deep-equal": {
@@ -7795,10 +7809,10 @@
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-extendable": "0.1.1",
-				"is-plain-object": "2.0.4",
-				"split-string": "3.1.0"
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -7807,7 +7821,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -7824,8 +7838,8 @@
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.2"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"shebang-command": {
@@ -7834,7 +7848,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -7873,14 +7887,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "0.11.2",
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"map-cache": "0.2.2",
-				"source-map": "0.5.7",
-				"source-map-resolve": "0.5.2",
-				"use": "3.1.1"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -7898,7 +7912,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
@@ -7907,7 +7921,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"ms": {
@@ -7924,9 +7938,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"snapdragon-util": "3.0.1"
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -7935,7 +7949,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -7944,7 +7958,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -7953,7 +7967,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -7962,9 +7976,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"kind-of": {
@@ -7981,7 +7995,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.2.0"
 			}
 		},
 		"source-list-map": {
@@ -8002,11 +8016,11 @@
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
-				"atob": "2.1.2",
-				"decode-uri-component": "0.2.0",
-				"resolve-url": "0.2.1",
-				"source-map-url": "0.4.0",
-				"urix": "0.1.0"
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -8015,7 +8029,7 @@
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 			"dev": true,
 			"requires": {
-				"source-map": "0.5.7"
+				"source-map": "^0.5.6"
 			}
 		},
 		"source-map-url": {
@@ -8030,8 +8044,8 @@
 			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.2"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -8046,8 +8060,8 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "2.2.0",
-				"spdx-license-ids": "3.0.2"
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -8062,7 +8076,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2"
+				"extend-shallow": "^3.0.0"
 			}
 		},
 		"sprintf-js": {
@@ -8077,15 +8091,15 @@
 			"integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
 			"dev": true,
 			"requires": {
-				"asn1": "0.2.4",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.2",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.2",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"ssri": {
@@ -8094,7 +8108,7 @@
 			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"stack-utils": {
@@ -8109,8 +8123,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "0.2.5",
-				"object-copy": "0.1.0"
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -8119,7 +8133,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -8136,8 +8150,8 @@
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6"
+				"inherits": "~2.0.1",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"stream-each": {
@@ -8146,8 +8160,8 @@
 			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.1",
-				"stream-shift": "1.0.0"
+				"end-of-stream": "^1.1.0",
+				"stream-shift": "^1.0.0"
 			}
 		},
 		"stream-http": {
@@ -8156,11 +8170,11 @@
 			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
 			"dev": true,
 			"requires": {
-				"builtin-status-codes": "3.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6",
-				"to-arraybuffer": "1.0.1",
-				"xtend": "4.0.1"
+				"builtin-status-codes": "^3.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.3.6",
+				"to-arraybuffer": "^1.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"stream-shift": {
@@ -8175,8 +8189,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "1.0.0",
-				"strip-ansi": "4.0.0"
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8191,7 +8205,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -8202,8 +8216,8 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8218,7 +8232,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -8229,9 +8243,9 @@
 			"integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"es-abstract": "1.12.0",
-				"function-bind": "1.1.1"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.0",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
@@ -8240,7 +8254,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -8249,7 +8263,7 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
@@ -8258,7 +8272,7 @@
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "0.2.1"
+				"is-utf8": "^0.2.0"
 			}
 		},
 		"strip-eof": {
@@ -8273,7 +8287,7 @@
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"symbol-tree": {
@@ -8294,11 +8308,11 @@
 			"integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"micromatch": "2.3.11",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"require-main-filename": "1.0.1"
+				"arrify": "^1.0.1",
+				"micromatch": "^2.3.11",
+				"object-assign": "^4.1.0",
+				"read-pkg-up": "^1.0.1",
+				"require-main-filename": "^1.0.1"
 			}
 		},
 		"throat": {
@@ -8313,8 +8327,8 @@
 			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.6",
-				"xtend": "4.0.1"
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
 			}
 		},
 		"timers-browserify": {
@@ -8323,7 +8337,7 @@
 			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
 			"dev": true,
 			"requires": {
-				"setimmediate": "1.0.5"
+				"setimmediate": "^1.0.4"
 			}
 		},
 		"tmpl": {
@@ -8350,7 +8364,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"to-regex": {
@@ -8359,10 +8373,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"regex-not": "1.0.2",
-				"safe-regex": "1.1.0"
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -8371,8 +8385,8 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1"
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -8381,7 +8395,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				}
 			}
@@ -8392,8 +8406,8 @@
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"dev": true,
 			"requires": {
-				"psl": "1.1.29",
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -8410,7 +8424,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "2.1.1"
+				"punycode": "^2.1.0"
 			}
 		},
 		"trim-right": {
@@ -8437,7 +8451,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -8452,7 +8466,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"typedarray": {
@@ -8468,8 +8482,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"commander": "2.17.1",
-				"source-map": "0.6.1"
+				"commander": "~2.17.1",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"commander": {
@@ -8494,14 +8508,14 @@
 			"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
 			"dev": true,
 			"requires": {
-				"cacache": "10.0.4",
-				"find-cache-dir": "1.0.0",
-				"schema-utils": "0.4.7",
-				"serialize-javascript": "1.5.0",
-				"source-map": "0.6.1",
-				"uglify-es": "3.3.9",
-				"webpack-sources": "1.3.0",
-				"worker-farm": "1.6.0"
+				"cacache": "^10.0.4",
+				"find-cache-dir": "^1.0.0",
+				"schema-utils": "^0.4.5",
+				"serialize-javascript": "^1.4.0",
+				"source-map": "^0.6.1",
+				"uglify-es": "^3.3.4",
+				"webpack-sources": "^1.1.0",
+				"worker-farm": "^1.5.2"
 			},
 			"dependencies": {
 				"commander": {
@@ -8522,8 +8536,8 @@
 					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
 					"dev": true,
 					"requires": {
-						"commander": "2.13.0",
-						"source-map": "0.6.1"
+						"commander": "~2.13.0",
+						"source-map": "~0.6.1"
 					}
 				}
 			}
@@ -8546,8 +8560,8 @@
 			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
 			"dev": true,
 			"requires": {
-				"unicode-canonical-property-names-ecmascript": "1.0.4",
-				"unicode-property-aliases-ecmascript": "1.0.4"
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
 			}
 		},
 		"unicode-match-property-value-ecmascript": {
@@ -8568,10 +8582,10 @@
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"get-value": "2.0.6",
-				"is-extendable": "0.1.1",
-				"set-value": "0.4.3"
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -8580,7 +8594,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"set-value": {
@@ -8589,10 +8603,10 @@
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"to-object-path": "0.3.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
 					}
 				}
 			}
@@ -8603,7 +8617,7 @@
 			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
 			"dev": true,
 			"requires": {
-				"unique-slug": "2.0.1"
+				"unique-slug": "^2.0.0"
 			}
 		},
 		"unique-slug": {
@@ -8612,7 +8626,7 @@
 			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
 			"dev": true,
 			"requires": {
-				"imurmurhash": "0.1.4"
+				"imurmurhash": "^0.1.4"
 			}
 		},
 		"unset-value": {
@@ -8621,8 +8635,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "0.3.1",
-				"isobject": "3.0.1"
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"has-value": {
@@ -8631,9 +8645,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "0.1.4",
-						"isobject": "2.1.0"
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -8667,7 +8681,7 @@
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 			"dev": true,
 			"requires": {
-				"punycode": "2.1.1"
+				"punycode": "^2.1.0"
 			}
 		},
 		"urix": {
@@ -8721,8 +8735,8 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"object.getownpropertydescriptors": "2.0.3"
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
 		"uuid": {
@@ -8743,8 +8757,8 @@
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "3.0.2",
-				"spdx-expression-parse": "3.0.0"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"validator": {
@@ -8758,9 +8772,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"vm-browserify": {
@@ -8778,7 +8792,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "0.1.3"
+				"browser-process-hrtime": "^0.1.2"
 			}
 		},
 		"walker": {
@@ -8787,7 +8801,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.11"
+				"makeerror": "1.0.x"
 			}
 		},
 		"watch": {
@@ -8796,8 +8810,8 @@
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"dev": true,
 			"requires": {
-				"exec-sh": "0.2.2",
-				"minimist": "1.2.0"
+				"exec-sh": "^0.2.0",
+				"minimist": "^1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -8814,9 +8828,9 @@
 			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 			"dev": true,
 			"requires": {
-				"chokidar": "2.0.4",
-				"graceful-fs": "4.1.15",
-				"neo-async": "2.6.0"
+				"chokidar": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"neo-async": "^2.5.0"
 			}
 		},
 		"webidl-conversions": {
@@ -8835,26 +8849,26 @@
 				"@webassemblyjs/helper-module-context": "1.7.11",
 				"@webassemblyjs/wasm-edit": "1.7.11",
 				"@webassemblyjs/wasm-parser": "1.7.11",
-				"acorn": "5.7.3",
-				"acorn-dynamic-import": "3.0.0",
-				"ajv": "6.5.5",
-				"ajv-keywords": "3.2.0",
-				"chrome-trace-event": "1.0.0",
-				"enhanced-resolve": "4.1.0",
-				"eslint-scope": "4.0.0",
-				"json-parse-better-errors": "1.0.2",
-				"loader-runner": "2.3.1",
-				"loader-utils": "1.1.0",
-				"memory-fs": "0.4.1",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"neo-async": "2.6.0",
-				"node-libs-browser": "2.1.0",
-				"schema-utils": "0.4.7",
-				"tapable": "1.1.0",
-				"uglifyjs-webpack-plugin": "1.3.0",
-				"watchpack": "1.6.0",
-				"webpack-sources": "1.3.0"
+				"acorn": "^5.6.2",
+				"acorn-dynamic-import": "^3.0.0",
+				"ajv": "^6.1.0",
+				"ajv-keywords": "^3.1.0",
+				"chrome-trace-event": "^1.0.0",
+				"enhanced-resolve": "^4.1.0",
+				"eslint-scope": "^4.0.0",
+				"json-parse-better-errors": "^1.0.2",
+				"loader-runner": "^2.3.0",
+				"loader-utils": "^1.1.0",
+				"memory-fs": "~0.4.1",
+				"micromatch": "^3.1.8",
+				"mkdirp": "~0.5.0",
+				"neo-async": "^2.5.0",
+				"node-libs-browser": "^2.0.0",
+				"schema-utils": "^0.4.4",
+				"tapable": "^1.1.0",
+				"uglifyjs-webpack-plugin": "^1.2.4",
+				"watchpack": "^1.5.0",
+				"webpack-sources": "^1.3.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -8869,10 +8883,10 @@
 					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "2.0.1",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.4.1",
-						"uri-js": "4.2.2"
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
 					}
 				},
 				"arr-diff": {
@@ -8893,16 +8907,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.3",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -8911,7 +8925,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -8931,13 +8945,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -8946,7 +8960,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -8955,7 +8969,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -8964,7 +8978,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -8973,7 +8987,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -8984,7 +8998,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -8993,7 +9007,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -9004,9 +9018,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -9023,14 +9037,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -9039,7 +9053,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -9048,7 +9062,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -9065,10 +9079,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -9077,7 +9091,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -9088,7 +9102,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -9097,7 +9111,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -9106,9 +9120,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"is-number": {
@@ -9117,7 +9131,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -9126,7 +9140,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -9149,19 +9163,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.13",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"ms": {
@@ -9178,16 +9192,16 @@
 			"integrity": "sha512-Cnqo7CeqeSvC6PTdts+dywNi5CRlIPbLx1AoUPK2T6vC1YAugMG3IOoO9DmEscd+Dghw7uRlnzV1KwOe5IrtgQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"cross-spawn": "6.0.5",
-				"enhanced-resolve": "4.1.0",
-				"global-modules-path": "2.3.0",
-				"import-local": "2.0.0",
-				"interpret": "1.1.0",
-				"loader-utils": "1.1.0",
-				"supports-color": "5.5.0",
-				"v8-compile-cache": "2.0.2",
-				"yargs": "12.0.2"
+				"chalk": "^2.4.1",
+				"cross-spawn": "^6.0.5",
+				"enhanced-resolve": "^4.1.0",
+				"global-modules-path": "^2.3.0",
+				"import-local": "^2.0.0",
+				"interpret": "^1.1.0",
+				"loader-utils": "^1.1.0",
+				"supports-color": "^5.5.0",
+				"v8-compile-cache": "^2.0.2",
+				"yargs": "^12.0.2"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -9211,13 +9225,13 @@
 					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "6.0.5",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"find-up": {
@@ -9226,7 +9240,7 @@
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
-						"locate-path": "3.0.0"
+						"locate-path": "^3.0.0"
 					}
 				},
 				"import-local": {
@@ -9235,8 +9249,8 @@
 					"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
 					"dev": true,
 					"requires": {
-						"pkg-dir": "3.0.0",
-						"resolve-cwd": "2.0.0"
+						"pkg-dir": "^3.0.0",
+						"resolve-cwd": "^2.0.0"
 					}
 				},
 				"invert-kv": {
@@ -9251,7 +9265,7 @@
 					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 					"dev": true,
 					"requires": {
-						"invert-kv": "2.0.0"
+						"invert-kv": "^2.0.0"
 					}
 				},
 				"locate-path": {
@@ -9260,8 +9274,8 @@
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
-						"p-locate": "3.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"mem": {
@@ -9270,9 +9284,9 @@
 					"integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
 					"dev": true,
 					"requires": {
-						"map-age-cleaner": "0.1.2",
-						"mimic-fn": "1.2.0",
-						"p-is-promise": "1.1.0"
+						"map-age-cleaner": "^0.1.1",
+						"mimic-fn": "^1.0.0",
+						"p-is-promise": "^1.1.0"
 					}
 				},
 				"os-locale": {
@@ -9281,9 +9295,9 @@
 					"integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
 					"dev": true,
 					"requires": {
-						"execa": "0.10.0",
-						"lcid": "2.0.0",
-						"mem": "4.0.0"
+						"execa": "^0.10.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
 					}
 				},
 				"p-limit": {
@@ -9292,7 +9306,7 @@
 					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
 					"dev": true,
 					"requires": {
-						"p-try": "2.0.0"
+						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
@@ -9301,7 +9315,7 @@
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
-						"p-limit": "2.0.0"
+						"p-limit": "^2.0.0"
 					}
 				},
 				"p-try": {
@@ -9316,7 +9330,7 @@
 					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 					"dev": true,
 					"requires": {
-						"find-up": "3.0.0"
+						"find-up": "^3.0.0"
 					}
 				},
 				"yargs": {
@@ -9325,18 +9339,18 @@
 					"integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
 					"dev": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "2.0.0",
-						"find-up": "3.0.0",
-						"get-caller-file": "1.0.3",
-						"os-locale": "3.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "10.1.0"
+						"cliui": "^4.0.0",
+						"decamelize": "^2.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^10.1.0"
 					}
 				},
 				"yargs-parser": {
@@ -9345,7 +9359,7 @@
 					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -9356,8 +9370,8 @@
 			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
 			"dev": true,
 			"requires": {
-				"source-list-map": "2.0.1",
-				"source-map": "0.6.1"
+				"source-list-map": "^2.0.0",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -9389,9 +9403,9 @@
 			"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "4.7.0",
-				"tr46": "1.0.1",
-				"webidl-conversions": "4.0.2"
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"which": {
@@ -9400,7 +9414,7 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
@@ -9421,7 +9435,7 @@
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
 			"dev": true,
 			"requires": {
-				"errno": "0.1.7"
+				"errno": "~0.1.7"
 			}
 		},
 		"wrap-ansi": {
@@ -9430,8 +9444,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -9440,7 +9454,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -9449,9 +9463,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -9468,9 +9482,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.15",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"xml-name-validator": {
@@ -9509,18 +9523,18 @@
 			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 			"dev": true,
 			"requires": {
-				"cliui": "4.1.0",
-				"decamelize": "1.2.0",
-				"find-up": "2.1.0",
-				"get-caller-file": "1.0.3",
-				"os-locale": "2.1.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "9.0.2"
+				"cliui": "^4.0.0",
+				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^9.0.2"
 			}
 		},
 		"yargs-parser": {
@@ -9529,7 +9543,7 @@
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "4.1.0"
+				"camelcase": "^4.1.0"
 			},
 			"dependencies": {
 				"camelcase": {

--- a/src/withValidation.js
+++ b/src/withValidation.js
@@ -173,6 +173,7 @@ function withValidation(ComposedComponent) {
 					validationResult={validationResult}
 					isInvalid={isInvalid}
 					validationMessage={validationMessage}
+					validator={validator}
 					name={name}
 				/>
 			);


### PR DESCRIPTION
At the moment it is not possible to pass the same `validator` to a child component wrapped in `withValidation` that needs to pass the validator even further to its own child components.
This hinders putting validation in separate blocks/components and at the same time validate with the same validator. 