### PR TITLE
[ISSUE] Validates using whole form state rather then fragments

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "build/index.js",
 	"scripts": {
 		"test": "jest --runInBand",
-		"start": "webpack --watch",
+		"start": "webpack --watch --mode development",
 		"build": "webpack",
 		"clean": "rm -rf build"
 	},

--- a/src/FormValidator.js
+++ b/src/FormValidator.js
@@ -2,6 +2,7 @@ import { Component } from "react";
 import validator from "validator";
 import { bindValue } from "./form-utils";
 import objectPath from "object-path";
+import { bindInputValue } from "./index";
 
 const DEBUG = 0;
 
@@ -71,9 +72,9 @@ export default class FormValidator {
 	/**
 	 * Validates provided form state agains registered validation rules.
 	 *
-	 * @param {Object} form
+	 * @param {Object=} form
 	 */
-	validate(form) {
+	validate(form = this.formState) {
 		const validation = this.validationResult || this.valid();
 		const invalidFieldsInValidationAttempt = {};
 
@@ -169,7 +170,7 @@ export default class FormValidator {
 		fieldValidations.forEach(rule => {
 			this.log(
 				`Registering field validation rule ${rule.name} for field ${rule.field} ${
-					rule.groupId ? "(group " + rule.groupId + ")" : ""
+				rule.groupId ? "(group " + rule.groupId + ")" : ""
 				}`
 			);
 
@@ -217,6 +218,16 @@ export default class FormValidator {
 		else if (Array.isArray(value)) return value.length === 0;
 		else if (type === "object") return value === {};
 		else return !!value;
+	}
+
+	/**
+	 * Sets input value on validation form state.
+	 * 
+	 * @param {Object} event
+	 */
+	setInputValue(event) {
+		this.formState = bindInputValue(event, this.formState);
+		return this;
 	}
 
 	/**

--- a/src/withValidation.js
+++ b/src/withValidation.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import FormValidator from "./FormValidator";
-import { bindInputValue } from "./form-utils";
 
 /**
  * Higher order Component (HoC) that adds validation logic to
@@ -142,8 +141,7 @@ function withValidation(ComposedComponent) {
 
 		handleBlur = e => {
 			if (this.validateOn.includes("blur") && this.validator) {
-				const fieldState = bindInputValue(e, {});
-				this.validator.validate(fieldState);
+				this.validator.setInputValue(e).validate();
 			}
 
 			this.props.onBlur && this.props.onBlur(e);
@@ -151,8 +149,7 @@ function withValidation(ComposedComponent) {
 
 		handleChange = e => {
 			if (this.validateOn.includes("change") && this.validator) {
-				const fieldState = bindInputValue(e, {});
-				this.validator.validate(fieldState);
+				this.validator.setInputValue(e).validate();
 			}
 
 			this.props.onChange && this.props.onChange(e);


### PR DESCRIPTION
This fix will change so the complete validators form state is used during validation rather then "fragments" of it.

This turned out to cause an issue when validating a nested array `foo.1.bar` where the binding would create an empty item at index `0` which caused strange things to happen.

With this change it will instead set value in the real, complete array.